### PR TITLE
Make tombstone cleanup configurable, make query delay configurable

### DIFF
--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	RescoreLimit           int
 	PQ                     string
 	SkipAsyncReady         bool
+	SkipTombstonesEmpty    bool
 	PQRatio                uint
 	PQSegments             uint
 	TrainingLimit          int
@@ -53,6 +54,7 @@ type Config struct {
 	UpdateIterations       int
 	Offset                 int
 	CleanupIntervalSeconds int
+	QueryDelaySeconds      int
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
- add `--skipTombstonesEmpty` to not wait for tombstone cleanup
- add `--queryDelaySeconds 10` to wait for less time between querying (i.e. 10 seconds)