### PR TITLE
Fix case when memstats is empty

### DIFF
--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -784,6 +784,7 @@ func runQueries(cfg *Config, importTime time.Duration, testData [][]float32, nei
 	memstats, err := readMemoryMetrics(cfg)
 	if err != nil {
 		log.Warnf("Error reading memory stats: %v", err)
+		memstats = &Memstats{}
 	}
 
 	client := createClient(cfg)


### PR DESCRIPTION
If an external cluster is used with no available prometheus metrics this prevents a crash.