### PR TITLE
Filtered benchmarks

### DIFF
--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	CleanupIntervalSeconds int
 	QueryDelaySeconds      int
 	DynamicThreshold       int
+	Filter                 bool
 }
 
 func (c *Config) Validate() error {

--- a/benchmarker/cmd/dataset.go
+++ b/benchmarker/cmd/dataset.go
@@ -120,7 +120,7 @@ func benchmarkDataset(cfg Config, queries Queries) Results {
 
 		if cfg.API == "grpc" {
 			return QueryWithNeighbors{
-				Query: nearVectorQueryGrpc(cfg.ClassName, queries[i], cfg.Limit, cfg.Tenant),
+				Query: nearVectorQueryGrpc(cfg.ClassName, queries[i], cfg.Limit, cfg.Tenant, 0),
 			}
 		}
 

--- a/benchmarker/requirements.txt
+++ b/benchmarker/requirements.txt
@@ -13,3 +13,5 @@ pytz==2024.1
 seaborn==0.13.2
 six==1.16.0
 tzdata==2024.1
+faiss-cpu
+h5py

--- a/benchmarker/scripts/generate-filtered-dataset.py
+++ b/benchmarker/scripts/generate-filtered-dataset.py
@@ -1,0 +1,104 @@
+import h5py
+import numpy as np
+import faiss
+import json
+import random
+import argparse
+
+def generate_categorical_text(distribution, num_categories):
+    midpoint = num_categories // 2
+    if distribution == "uniform":
+        return random.randint(1, num_categories)
+    else:
+        return int(np.clip(np.random.normal(loc=midpoint, scale=midpoint / 2), 1, num_categories))
+    
+def generate_json_properties(name, value):
+    properties = {
+        name: str(value),
+    }
+    return json.dumps(properties)
+
+
+def main(args):
+    original = h5py.File(args.original_file, "r")
+
+    print(f"Train dimensions: {original['train'].shape}")
+    print(f"Test dimensions: {original['test'].shape}")
+    print(f"Neighbors dimensions: {original['neighbors'].shape}")
+
+    target = h5py.File(args.target_file, "w")
+    target.create_dataset("train", data=original["train"][:])
+    target.create_dataset("test", data=original["test"][:])
+
+    name = f"{args.distribution}Text{args.categories}"
+    print(f"Building categorical filters for {name}...")
+
+    train_categories = [generate_categorical_text(args.distribution, args.categories) for _ in range(original["train"].shape[0])]
+    test_categories = [generate_categorical_text(args.distribution, args.categories) for _ in range(original["test"].shape[0])]
+
+    train_properties = [generate_json_properties(name, category) for category in train_categories]
+    test_properties = [generate_json_properties(name, category) for category in test_categories]
+
+    target.create_dataset("train_properties", data=np.array(train_properties, dtype=h5py.special_dtype(vlen=str)))
+    target.create_dataset("test_properties", data=np.array(test_properties, dtype=h5py.special_dtype(vlen=str)))
+
+    filters = []
+    for value in test_categories:
+        filter_data = {
+            "path": [name],
+            "valueText": value,
+            "operation": "Equal"
+        }
+        filters.append(json.dumps(filter_data))
+
+    target.create_dataset("filters", data=np.array(filters, dtype=h5py.special_dtype(vlen=str)))
+
+    print(f"filter[0]: {filters[0]}")
+    print(f"filter[1]: {filters[1]}")
+    print(f"train_properties[0]: {train_properties[0]}")
+    print(f"train_properties[1]: {train_properties[1]}")
+
+    dimensions = original["train"].shape[1]
+
+    print(f"Building flat index for {dimensions} dimensions...")
+    index = faiss.IndexFlatIP(dimensions)
+    index.add(original["train"][:])
+
+    neighbors_data = np.zeros((len(filters), args.limit), dtype=np.int64)
+
+    for i, filter_data in enumerate(filters):
+        json_filter = json.loads(filter_data)
+        category = int(json_filter["valueText"])
+        train_indices = [j for j in range(len(train_categories)) if train_categories[j] == category]
+        selector = faiss.IDSelectorArray(np.array(train_indices, dtype=np.int64))
+        search_params = faiss.SearchParameters(sel=selector)
+        D, I = index.search(original["test"][:][i].reshape(1, -1), args.limit, params=search_params)
+        neighbors_data[i] = I[0]
+
+        if i == 0:
+            print(f"Test query {i}:")
+            print(f"Category: {category}")
+            print(f"Length of train_indices: {len(train_indices)}")
+            print(f"Distances: {D.shape}")
+            print(f"Indices: {I.shape}")
+            print(f"Nearest neighbors: {I[0]}")
+            print()
+
+            print(f"Distance[0]: {D[0][0]}")
+            print(f"Distance[1]: {D[0][1]}")
+        break
+
+    target.create_dataset("neighbors", data=neighbors_data)
+    target.close()
+    print("Successfully generated filtered dataset")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate filtered dataset")
+    parser.add_argument("original_file", help="Path to the original HDF5 file")
+    parser.add_argument("target_file", help="Path to the target HDF5 file")
+    parser.add_argument("--distribution", default="normal", choices=["uniform", "normal"], help="Distribution type (default: normal)")
+    parser.add_argument("--categories", type=int, default=20, help="Number of categories for uniform distribution or clipping range for normal distribution (default: 20)")
+    parser.add_argument("--limit", type=int, default=100, help="Limit of each query (default: 100)")
+
+    args = parser.parse_args()
+    main(args)

--- a/benchmarker/scripts/generate-filtered-dataset.py
+++ b/benchmarker/scripts/generate-filtered-dataset.py
@@ -30,7 +30,8 @@ def main(args):
     target.create_dataset("train", data=original["train"][:])
     target.create_dataset("test", data=original["test"][:])
 
-    name = f"{args.distribution}Text{args.categories}"
+    # name = f"{args.distribution}Text{args.categories}"
+    name = "category"
     print(f"Building categorical filters for {name}...")
 
     train_categories = [generate_categorical_text(args.distribution, args.categories) for _ in range(original["train"].shape[0])]
@@ -39,6 +40,9 @@ def main(args):
     train_properties = [generate_json_properties(name, category) for category in train_categories]
     test_properties = [generate_json_properties(name, category) for category in test_categories]
 
+    target.create_dataset("train_categories", data=np.array(train_categories, dtype=np.int64))
+    target.create_dataset("test_categories", data=np.array(test_categories, dtype=np.int64))
+
     target.create_dataset("train_properties", data=np.array(train_properties, dtype=h5py.special_dtype(vlen=str)))
     target.create_dataset("test_properties", data=np.array(test_properties, dtype=h5py.special_dtype(vlen=str)))
 
@@ -46,7 +50,7 @@ def main(args):
     for value in test_categories:
         filter_data = {
             "path": [name],
-            "valueText": value,
+            "valueText": str(value),
             "operation": "Equal"
         }
         filters.append(json.dumps(filter_data))
@@ -86,7 +90,6 @@ def main(args):
 
             print(f"Distance[0]: {D[0][0]}")
             print(f"Distance[1]: {D[0][1]}")
-        break
 
     target.create_dataset("neighbors", data=neighbors_data)
     target.close()
@@ -97,7 +100,7 @@ if __name__ == "__main__":
     parser.add_argument("original_file", help="Path to the original HDF5 file")
     parser.add_argument("target_file", help="Path to the target HDF5 file")
     parser.add_argument("--distribution", default="normal", choices=["uniform", "normal"], help="Distribution type (default: normal)")
-    parser.add_argument("--categories", type=int, default=20, help="Number of categories for uniform distribution or clipping range for normal distribution (default: 20)")
+    parser.add_argument("--categories", type=int, default=10, help="Number of categories for uniform distribution or clipping range for normal distribution (default: 20)")
     parser.add_argument("--limit", type=int, default=100, help="Limit of each query (default: 100)")
 
     args = parser.parse_args()


### PR DESCRIPTION
Notes
- Allows for simple filters in the benchmarker using a new `--filter` option
- Adds utility file to convert existing hdf5 ann benchmark files to have uniform or normal distributed categorical fields
- I'm explicitly using `valueText` so we test string categorical fields which should be more common