### PR TITLE
Fixes for auth and skipping metrics in WCS

### DIFF
--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	SQ                     string
 	SkipAsyncReady         bool
 	SkipTombstonesEmpty    bool
+	SkipMemoryStats        bool
 	PQRatio                uint
 	PQSegments             uint
 	TrainingLimit          int


### PR DESCRIPTION
- Add a way to skip metrics collection (if not running locally)
- The Weaviate go client errors if AuthConfig and Connection client is set so disable retryable client in that situation