### PR TITLE
Switch to new filterStrategy naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ benchmark-data
 results
 output.png
 .venv
+.env

--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -44,8 +44,7 @@ Flags:
       --efConstruction int           Set Weaviate efConstruction parameter (default 256) (default 256)
       --existingSchema               Leave the schema as-is (default false)
       --filter                       Threshold to trigger the update in the dynamic index (default 10 000)
-      --filteredSearch               Use an ACORN like search
-      --filteredSearchCache          Cache two hops expansion for ACORN like search
+      --filterStrategy               Use a different filter strategy such as "acorn"
       --flatSearchCutoff int         Flat search cut off (default 40 000) (default 40000)
   -f, --format string                Output format, one of [text, json] (default "text")
   -h, --help                         help for ann-benchmark

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -281,12 +281,7 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 		log.Fatalf("Unknown index type %s", cfg.IndexType)
 	}
 
-	if cfg.FilteredSearch {
-		vectorIndexConfig["filteredSearch"] = map[string]interface{}{
-			"enabled": true,
-			"cache2h": cfg.FilteredSearchCache,
-		}
-	}
+	vectorIndexConfig["filterStrategy"] = cfg.FilterStrategy
 
 	classObj.VectorIndexConfig = vectorIndexConfig
 
@@ -1124,10 +1119,8 @@ func initAnnBenchmark() {
 		"filter", false, "Threshold to trigger the update in the dynamic index (default 10 000)")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.FlatSearchCutoff,
 		"flatSearchCutoff", 40000, "Flat search cut off (default 40 000)")
-	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.FilteredSearch,
-		"filteredSearch", false, "Use an ACORN like search")
-	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.FilteredSearchCache,
-		"filteredSearchCache", false, "Cache two hops expansion for ACORN like search")
+	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.FilterStrategy,
+		"filterStrategy", "sweeping", "Use a different filter strategy (options are sweeping or acorn)")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.ReplicationFactor,
 		"replicationFactor", 1, "Replication factor")
 }

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -61,8 +61,7 @@ type Config struct {
 	DynamicThreshold       int
 	Filter                 bool
 	FlatSearchCutoff       int
-	FilteredSearch         bool
-	FilteredSearchCache    bool
+	FilterStrategy         string
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
- Can now use acorn by specifying `--filterStrategy acorn`. Will by default use `--filterStrategy sweeping`