### PR TITLE
Deprecate older commands, update random-vectors

### DIFF
--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -10,11 +10,9 @@ Usage:
   benchmarker [command]
 
 Available Commands:
-  ann-benchmark  Benchmark ANN Benchmark style hdf5 files (this is generally what you want to use)
-  dataset        Benchmark vectors from an existing dataset
+  ann-benchmark  Benchmark ANN Benchmark style datasets
   help           Help about any command
-  random-text    Benchmark nearText searches
-  random-vectors Benchmark nearVector searches
+  random-vectors Benchmark random vector queries
   raw            Benchmark raw GraphQL queries
 
 Flags:
@@ -129,7 +127,7 @@ go run . \
   --dimensions 384 \
   --queries 10000 \
   --parallel 8 \
-  --api graphql \
+  --api grpc \
   --limit 10
 ```
 
@@ -158,7 +156,7 @@ benchmarker \
   --dimensions 384 \
   --queries 10000 \
   --parallel 8 \
-  --api graphql \
+  --api grpc \
   --limit 10
 ```
 

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -998,7 +998,7 @@ func runQueries(cfg *Config, importTime time.Duration, testData [][]float32, nei
 
 var annBenchmarkCommand = &cobra.Command{
 	Use:   "ann-benchmark",
-	Short: "Benchmark ANN Benchmark style hdf5 files",
+	Short: "Benchmark ANN Benchmark style datasets",
 	Long:  `Run a gRPC benchmark on an hdf5 file in the format of ann-benchmarks.com`,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -36,10 +36,11 @@ func processQueueHttp(queue []QueryWithNeighbors, cfg *Config, c *http.Client, m
 		r := bytes.NewReader(query.Query)
 		before := time.Now()
 		var url string
+		origin := fmt.Sprintf("%s://%s", cfg.HttpScheme, cfg.HttpOrigin)
 		if cfg.API == "graphql" {
-			url = cfg.Origin + "/v1/graphql"
+			url = origin + "/v1/graphql"
 		} else if cfg.API == "rest" {
-			url = fmt.Sprintf("%s/v1/objects/%s/_search", cfg.Origin, cfg.ClassName)
+			url = fmt.Sprintf("%s/v1/objects/%s/_search", origin, cfg.ClassName)
 		}
 		req, err := http.NewRequest("POST", url, r)
 		if err != nil {

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -96,7 +96,7 @@ func (c *Config) validateCommon() error {
 	}
 
 	switch c.API {
-	case "graphql", "nearvector", "grpc":
+	case "graphql", "grpc":
 	default:
 		return errors.Errorf("unsupported API %q", c.API)
 	}
@@ -128,10 +128,6 @@ func (c Config) validateRandomText() error {
 }
 
 func (c Config) validateRandomVectors() error {
-	if c.Dimensions == 0 {
-		return errors.Errorf("dimensions must be set and larger than 0\n")
-	}
-
 	return nil
 }
 

--- a/benchmarker/cmd/dataset.go
+++ b/benchmarker/cmd/dataset.go
@@ -9,9 +9,10 @@ import (
 )
 
 var datasetCmd = &cobra.Command{
-	Use:   "dataset",
-	Short: "Benchmark vectors from an existing dataset",
-	Long:  `Specify an existing dataset as a list of query vectors in a .json file to parse the query vectors and then query them with the specified parallelism`,
+	Use:        "dataset",
+	Short:      "Benchmark vectors from an existing dataset",
+	Long:       `Specify an existing dataset as a list of query vectors in a .json file to parse the query vectors and then query them with the specified parallelism`,
+	Deprecated: "This command is deprecated and will be removed in the future",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := globalConfig
 		cfg.Mode = "dataset"
@@ -112,15 +113,9 @@ func benchmarkDataset(cfg Config, queries Queries) Results {
 			}
 		}
 
-		if cfg.API == "rest" {
-			return QueryWithNeighbors{
-				Query: nearVectorQueryJSONRest(cfg.ClassName, queries[i], cfg.Limit),
-			}
-		}
-
 		if cfg.API == "grpc" {
 			return QueryWithNeighbors{
-				Query: nearVectorQueryGrpc(&cfg, queries[i], cfg.Tenant, 0),
+				Query: nearVectorQueryGrpc(&cfg, queries[i], cfg.Tenant, -1),
 			}
 		}
 

--- a/benchmarker/cmd/random_text.go
+++ b/benchmarker/cmd/random_text.go
@@ -29,6 +29,7 @@ var randomTextCmd = &cobra.Command{
 	Use:   "random-text",
 	Short: "Benchmark nearText searches",
 	Long:  `Benchmark random nearText searches`,
+	Deprecated: "This command is deprecated and will be removed in the future",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := globalConfig
 

--- a/benchmarker/cmd/random_vectors.go
+++ b/benchmarker/cmd/random_vectors.go
@@ -31,7 +31,7 @@ func initRandomVectors() {
 	randomVectorsCmd.PersistentFlags().IntVarP(&globalConfig.Parallel,
 		"parallel", "p", numCPU, "Set the number of parallel threads which send queries")
 	randomVectorsCmd.PersistentFlags().StringVarP(&globalConfig.API,
-		"api", "a", "grpc", "API (graphql | rest | grpc) default and recommended grpc")
+		"api", "a", "grpc", "API (graphql | grpc) default and recommended is grpc")
 	randomVectorsCmd.PersistentFlags().IntVarP(&globalConfig.Limit,
 		"limit", "l", 10, "Set the query limit (top_k)")
 	randomVectorsCmd.PersistentFlags().IntVarP(&globalConfig.Dimensions,


### PR DESCRIPTION
This PR modernises the `random-vectors` subcommand to query for a specified duration, detect the dimensions from the class (unless provided) and use gRPC by default.

I have also marked `dataset` and `random-text` as deprecated for now because they do not support gRPC and are not used as part of the new benchmark suite. 