### PR TITLE
Add wait for shards to be ready after update

### DIFF
--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -1079,6 +1079,10 @@ var annBenchmarkCommand = &cobra.Command{
 						log.Fatalf("Error waiting for tombstones to be empty: %v", err)
 					}
 				}
+				if !cfg.SkipAsyncReady {
+					startTime := time.Now()
+					waitReady(&cfg, client, startTime, 30*time.Minute, 1000)
+				}
 
 				runQueries(&cfg, importTime, testData, neighbors, testFilters)
 


### PR DESCRIPTION
During the update runs, it is also convenient to wait for shards to be ready in case that Async indexing is configured. 