### PR TITLE
fix: Do not add vector index type to class creation

### DIFF
--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -213,9 +213,8 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 	}
 
 	var classObj = &models.Class{
-		Class:           cfg.ClassName,
-		Description:     fmt.Sprintf("Created by the Weaviate Benchmarker at %s", time.Now().String()),
-		VectorIndexType: cfg.IndexType,
+		Class:       cfg.ClassName,
+		Description: fmt.Sprintf("Created by the Weaviate Benchmarker at %s", time.Now().String()),
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled: multiTenancyEnabled,
 		},


### PR DESCRIPTION
There was a bug introduced in [PR](https://github.com/weaviate/weaviate-benchmarking/pull/47) that implies an error like:

```
go run main.go ann-benchmark -v ../datasets/custom_Multivector_lotte-recreation-reduced-vl.hdf5 -d dot --indexType hnsw  -m 128 --replicationFactor 3
panic: status code: 422, error: {"error":[{"message":"class.vectorIndexType \"hnsw\" can not be set if class.vectorConfig is configured"}]}


goroutine 1 [running]:
github.com/semi-technologies/weaviate-benchmarking/benchmarker/cmd.createSchema(0xc00034e288, 0xc0000a32c0)
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/cmd/ann_benchmark.go:357 +0x214e
github.com/semi-technologies/weaviate-benchmarking/benchmarker/cmd.init.func1(0xc0001e1a00?, {0xc272e2?, 0x4?, 0xc27486?})
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/cmd/ann_benchmark.go:1076 +0x1ae
github.com/spf13/cobra.(*Command).execute(0x1216580, {0xc0004555e0, 0xa, 0xa})
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/vendor/github.com/spf13/cobra/command.go:846 +0x671
github.com/spf13/cobra.(*Command).ExecuteC(0x12172a0)
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/vendor/github.com/spf13/cobra/command.go:950 +0x389
github.com/spf13/cobra.(*Command).Execute(...)
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/vendor/github.com/spf13/cobra/command.go:887
github.com/semi-technologies/weaviate-benchmarking/benchmarker/cmd.Execute()
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/cmd/root.go:49 +0x1a
main.main()
        /home/rodrigo_lopez/workspace/weaviate-benchmarking/benchmarker/main.go:6 +0xf
exit status 2
```


This PR reverts that line and avoids the error