### PR TITLE
add build-base package to APK

### DIFF
--- a/benchmarker/Dockerfile
+++ b/benchmarker/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.23-alpine AS builder
-RUN apk add --no-cache hdf5-dev gcc libc-dev python3 bash g++ musl-dev
+RUN apk add --no-cache build-base hdf5-dev gcc libc-dev python3 bash g++ musl-dev
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=1 go build -o benchmarker .


### PR DESCRIPTION
I did some tests and it seems that by including `build-base` fixes the issue. It seems to be related to the ARM64 and the way docker passes the `CC` env var.