### PR TITLE
ci: build based on branch name

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
   Push-Docker:
     name: push-docker
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub

--- a/benchmarker/Dockerfile
+++ b/benchmarker/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.23-alpine AS builder
-RUN apk add --no-cache build-base hdf5-dev gcc libc-dev python3 bash g++ musl-dev
+FROM golang:1.22-alpine AS builder
+RUN apk add --no-cache build-base hdf5-dev gcc libc-dev python3 bash g++ musl-dev make cmake
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=1 go build -o benchmarker .
 
-FROM golang:1.23-alpine
+FROM golang:1.22-alpine
 RUN apk add --no-cache hdf5-dev python3 bash
 WORKDIR /app
 COPY --from=builder /app/benchmarker /app/benchmarker

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -17,7 +17,7 @@ function init() {
 }
 
 function build_and_push_tag() {
-  if [ ! -z "$GITHUB_REF_NAME" ] && [ "$GITHUB_REF_TYPE" == "tag" ]; then
+  if [ ! -z "$GITHUB_REF_NAME" ] && [ "$GITHUB_REF_TYPE" == "tag"; then
     branch_name="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g')"
     tag_git="$DOCKER_REPO:$branch_name"
     tag_latest="$DOCKER_REPO:latest"
@@ -29,6 +29,18 @@ function build_and_push_tag() {
       --tag "$tag_latest" \
       ./benchmarker
   fi
+
+  if [ ! -z "$GITHUB_REF_NAME" ] && [ "$GITHUB_REF_TYPE" == "branch" ]; then
+    branch_name="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g')"
+    tag_git="$DOCKER_REPO:$branch_name"
+
+    echo "Tag & Push $tag_git"
+    docker buildx build --platform=linux/arm64,linux/amd64 \
+      --push \
+      --tag "$tag_git" \
+      ./benchmarker
+  fi
+
 }
 
 main


### PR DESCRIPTION
Create a container image based on the branch name if the action is triggered from CI GitHub manually. It will be pushed to the container registry. In this case, do not create the latest tag.

Additionally, there was a problem when building for ARM in AMD host of Github, to prevent it, reducing the alpine version fixes it.
