### PR TITLE
Add linear NDCG metric

### DIFF
--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -90,7 +90,29 @@ func processQueueHttp(queue []QueryWithNeighbors, cfg *Config, c *http.Client, m
 	}
 }
 
-func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.ClientConn, m *sync.Mutex, times *[]time.Duration, recall *[]float64) {
+func calculateLinearNDCG(ids []int, neighbors []int, k int) float64 {
+	neighborSet := make(map[int]bool)
+	for _, n := range neighbors[:k] { // Only consider top-k ground truth
+		neighborSet[n] = true
+	}
+
+	score := 0.0
+	for i := 0; i < min(k, len(ids)); i++ {
+		if neighborSet[ids[i]] {
+			score += 1.0 / float64(i+1) // Higher weight for earlier positions
+		}
+	}
+
+	// Normalize by perfect score
+	perfectScore := 0.0
+	for i := 0; i < k; i++ {
+		perfectScore += 1.0 / float64(i+1)
+	}
+
+	return score / perfectScore
+}
+
+func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.ClientConn, m *sync.Mutex, times *[]time.Duration, recall *[]float64, ndcg *[]float64) {
 
 	grpcClient := wv1.NewWeaviateClient(grpcConn)
 
@@ -131,12 +153,14 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 
 		neighborLimit := min(cfg.Limit, len(query.Neighbors))
 		recallQuery := float64(len(intersection(ids, query.Neighbors[:neighborLimit]))) / float64(neighborLimit)
+		ndcgQuery := calculateLinearNDCG(ids, query.Neighbors, neighborLimit)
 
-		log.Debugf("Query took %s, recall %f", took, recallQuery)
+		log.Debugf("Query took %s, recall %f, ndcg %f", took, recallQuery, ndcgQuery)
 
 		m.Lock()
 		*times = append(*times, took)
 		*recall = append(*recall, recallQuery)
+		*ndcg = append(*ndcg, ndcgQuery)
 		m.Unlock()
 	}
 }
@@ -144,6 +168,7 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 func benchmark(cfg Config, getQueryFn func(className string) QueryWithNeighbors) Results {
 	var times []time.Duration
 	var recall []float64
+	var ndcg []float64
 	m := &sync.Mutex{}
 
 	t := &http.Transport{
@@ -194,7 +219,7 @@ func benchmark(cfg Config, getQueryFn func(className string) QueryWithNeighbors)
 		go func(queue []QueryWithNeighbors) {
 			defer wg.Done()
 			if cfg.API == "grpc" {
-				processQueueGrpc(queue, &cfg, grpcConn, m, &times, &recall)
+				processQueueGrpc(queue, &cfg, grpcConn, m, &times, &recall, &ndcg)
 			} else {
 				processQueueHttp(queue, &cfg, httpClient, m, &times)
 			}
@@ -202,7 +227,7 @@ func benchmark(cfg Config, getQueryFn func(className string) QueryWithNeighbors)
 	}
 	wg.Wait()
 
-	return analyze(cfg, times, time.Since(before), recall)
+	return analyze(cfg, times, time.Since(before), recall, ndcg)
 }
 
 var targetPercentiles = []int{50, 90, 95, 98, 99}
@@ -220,9 +245,10 @@ type Results struct {
 	Failed            int
 	Parallelization   int
 	Recall            float64
+	NDCG              float64
 }
 
-func analyze(cfg Config, times []time.Duration, total time.Duration, recall []float64) Results {
+func analyze(cfg Config, times []time.Duration, total time.Duration, recall []float64, ndcg []float64) Results {
 	out := Results{Min: math.MaxInt64, PercentilesLabels: targetPercentiles}
 	var sum time.Duration
 
@@ -244,6 +270,11 @@ func analyze(cfg Config, times []time.Duration, total time.Duration, recall []fl
 		sumRecall += r
 	}
 
+	var sumNDCG float64
+	for _, r := range ndcg {
+		sumNDCG += r
+	}
+
 	out.Total = cfg.Queries
 	out.Failed = cfg.Queries - out.Successful
 	out.Parallelization = cfg.Parallel
@@ -251,6 +282,7 @@ func analyze(cfg Config, times []time.Duration, total time.Duration, recall []fl
 	out.Took = total
 	out.QueriesPerSecond = float64(len(times)) / float64(float64(total)/float64(time.Second))
 	out.Recall = sumRecall / float64(len(recall))
+	out.NDCG = sumNDCG / float64(len(ndcg))
 
 	sort.Slice(times, func(a, b int) bool {
 		return times[a] < times[b]
@@ -300,8 +332,8 @@ func (r Results) WriteTextTo(w io.Writer) (int64, error) {
 	}
 
 	n, err := w.Write([]byte(fmt.Sprintf(
-		"Results\nSuccessful: %d\nMin: %s\nMean: %s\n%sTook: %s\nQPS: %f\nRecall: %f\n",
-		r.Successful, r.Min, r.Mean, b.String(), r.Took, r.QueriesPerSecond, r.Recall)))
+		"Results\nSuccessful: %d\nMin: %s\nMean: %s\n%sTook: %s\nQPS: %f\nRecall: %f\nNDCG: %f\n",
+		r.Successful, r.Min, r.Mean, b.String(), r.Took, r.QueriesPerSecond, r.Recall, r.NDCG)))
 	return int64(n), err
 }
 
@@ -310,6 +342,7 @@ type resultsJSON struct {
 	Latencies          map[string]int64      `json:"latencies"`
 	LatenciesFormatted map[string]string     `json:"latenciesFormatted"`
 	Throughput         resultsJSONThroughput `json:"throughput"`
+	Quality            resultsJSONQuality    `json:"quality"`
 }
 
 type resultsJSONMetadata struct {
@@ -323,6 +356,11 @@ type resultsJSONMetadata struct {
 
 type resultsJSONThroughput struct {
 	QPS float64 `json:"qps"`
+}
+
+type resultsJSONQuality struct {
+	Recall float64 `json:"recall"`
+	NDCG   float64 `json:"ndcg"`
 }
 
 func (r Results) WriteJSONTo(w io.Writer) (int, error) {
@@ -345,6 +383,10 @@ func (r Results) WriteJSONTo(w io.Writer) (int, error) {
 		},
 		Throughput: resultsJSONThroughput{
 			QPS: r.QueriesPerSecond,
+		},
+		Quality: resultsJSONQuality{
+			Recall: r.Recall,
+			NDCG:   r.NDCG,
 		},
 	}
 


### PR DESCRIPTION
Chose to use linear NDCG instead of the normal logarithmic as this make particularly in high recall settings this makes the metric more sensitive.