### PR TITLE
Remove RQRescoreLimit param and only use RescoreLimit

### DIFF
--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -63,7 +63,7 @@ Flags:
   -q, --query                        Do not import data and only run query tests
       --queryDelaySeconds int        How long to wait before querying (default 30) (default 30)
       --queryDuration int            Instead of querying the test dataset once, query for the specified duration in seconds (default 0)
-      --rescoreLimit int             Rescore limit (default 256) for BQ (default 256)
+      --rescoreLimit int             Rescore limit. If not set, Weaviate will configure it automatically when rescoring is enabled
       --shards int                   Set number of Weaviate shards (default 1)
       --skipAsyncReady               Skip async ready (default false)
       --skipTombstonesEmpty          Skip waiting for tombstone to be empty after update (default false)

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -239,18 +239,20 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 			"flatSearchCutoff":       cfg.FlatSearchCutoff,
 		}
 		if cfg.PQ == "auto" {
-			vectorIndexConfig["pq"] = map[string]interface{}{
+			pqConfig := map[string]interface{}{
 				"enabled":       true,
-				"rescoreLimit":  cfg.RescoreLimit,
 				"segments":      cfg.PQSegments,
 				"trainingLimit": cfg.TrainingLimit,
 			}
-		} else if cfg.BQ {
-			vectorIndexConfig["bq"] = map[string]interface{}{
-				"enabled":      true,
-				"rescoreLimit": cfg.RescoreLimit,
-				"cache":        true,
+			if cfg.RescoreLimit > 0 {
+				pqConfig["rescoreLimit"] = cfg.RescoreLimit
 			}
+			vectorIndexConfig["pq"] = pqConfig
+		} else if cfg.BQ {
+			bqConfig := map[string]interface{}{
+				"enabled": true,
+			}
+			vectorIndexConfig["bq"] = bqConfig
 		} else if cfg.SQ == "auto" {
 			vectorIndexConfig = map[string]interface{}{
 				"distance":               cfg.DistanceMetric,
@@ -274,18 +276,21 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 				},
 			}
 		} else if cfg.RQ == "auto" {
+			rqConfig := map[string]interface{}{
+				"enabled":   true,
+				"dataBits":  cfg.RQDataBits,
+				"queryBits": cfg.RQQueryBits,
+				"rescore":   cfg.RQRescore,
+			}
+			if cfg.RescoreLimit > 0 {
+				rqConfig["rescoreLimit"] = cfg.RescoreLimit
+			}
 			vectorIndexConfig = map[string]interface{}{
 				"distance":               cfg.DistanceMetric,
 				"efConstruction":         float64(cfg.EfConstruction),
 				"maxConnections":         float64(cfg.MaxConnections),
 				"cleanupIntervalSeconds": cfg.CleanupIntervalSeconds,
-				"rq": map[string]interface{}{
-					"enabled":      true,
-					"dataBits":     cfg.RQDataBits,
-					"queryBits":    cfg.RQQueryBits,
-					"rescore":      cfg.RQRescore,
-					"rescoreLimit": cfg.RescoreLimit,
-				},
+				"rq":                     rqConfig,
 			}
 		}
 	} else if cfg.IndexType == "flat" {
@@ -293,11 +298,14 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 			"distance": cfg.DistanceMetric,
 		}
 		if cfg.BQ {
-			vectorIndexConfig["bq"] = map[string]interface{}{
-				"enabled":      true,
-				"rescoreLimit": cfg.RescoreLimit,
-				"cache":        cfg.Cache,
+			bqConfig := map[string]interface{}{
+				"enabled": true,
+				"cache":   cfg.Cache,
 			}
+			if cfg.RescoreLimit > 0 {
+				bqConfig["rescoreLimit"] = cfg.RescoreLimit
+			}
+			vectorIndexConfig["bq"] = bqConfig
 		}
 	} else if cfg.IndexType == "dynamic" {
 		log.WithFields(log.Fields{"threshold": cfg.DynamicThreshold}).Info("Building dynamic vector index")
@@ -312,18 +320,24 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 			},
 		}
 		if cfg.PQ == "auto" {
-			vectorIndexConfig["hnsw"].(map[string]interface{})["pq"] = map[string]interface{}{
+			pqConfig := map[string]interface{}{
 				"enabled":       true,
-				"rescoreLimit":  cfg.RescoreLimit,
 				"segments":      cfg.PQSegments,
 				"trainingLimit": cfg.TrainingLimit,
 			}
-		} else if cfg.BQ {
-			vectorIndexConfig["hnsw"].(map[string]interface{})["bq"] = map[string]interface{}{
-				"enabled":      true,
-				"rescoreLimit": cfg.RescoreLimit,
-				"cache":        true,
+			if cfg.RescoreLimit > 0 {
+				pqConfig["rescoreLimit"] = cfg.RescoreLimit
 			}
+			vectorIndexConfig["hnsw"].(map[string]interface{})["pq"] = pqConfig
+		} else if cfg.BQ {
+			bqConfig := map[string]interface{}{
+				"enabled": true,
+				"cache":   true,
+			}
+			if cfg.RescoreLimit > 0 {
+				bqConfig["rescoreLimit"] = cfg.RescoreLimit
+			}
+			vectorIndexConfig["hnsw"].(map[string]interface{})["bq"] = bqConfig
 		}
 	} else {
 		log.Fatalf("Unknown index type %s", cfg.IndexType)
@@ -343,18 +357,24 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 		if cfg.MultiVectorDimensions > 0 {
 			vectorIndexConfig = map[string]interface{}{}
 			if cfg.PQ == "auto" {
-				vectorIndexConfig["pq"] = map[string]interface{}{
+				pqConfig := map[string]interface{}{
 					"enabled":       true,
-					"rescoreLimit":  cfg.RescoreLimit,
 					"segments":      cfg.PQSegments,
 					"trainingLimit": cfg.TrainingLimit,
 				}
-			} else if cfg.BQ {
-				vectorIndexConfig["bq"] = map[string]interface{}{
-					"enabled":      true,
-					"rescoreLimit": cfg.RescoreLimit,
-					"cache":        true,
+				if cfg.RescoreLimit > 0 {
+					pqConfig["rescoreLimit"] = cfg.RescoreLimit
 				}
+				vectorIndexConfig["pq"] = pqConfig
+			} else if cfg.BQ {
+				bqConfig := map[string]interface{}{
+					"enabled": true,
+					"cache":   true,
+				}
+				if cfg.RescoreLimit > 0 {
+					bqConfig["rescoreLimit"] = cfg.RescoreLimit
+				}
+				vectorIndexConfig["bq"] = bqConfig
 			} else if cfg.SQ == "auto" {
 				vectorIndexConfig = map[string]interface{}{
 					"distance":               cfg.DistanceMetric,
@@ -367,18 +387,21 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 					},
 				}
 			} else if cfg.RQ == "auto" {
+				rqConfig := map[string]interface{}{
+					"enabled":     true,
+					"rqDataBits":  cfg.RQDataBits,
+					"rqQueryBits": cfg.RQQueryBits,
+					"rescore":     cfg.RQRescore,
+				}
+				if cfg.RescoreLimit > 0 {
+					rqConfig["rescoreLimit"] = cfg.RescoreLimit
+				}
 				vectorIndexConfig = map[string]interface{}{
 					"distance":               cfg.DistanceMetric,
 					"efConstruction":         float64(cfg.EfConstruction),
 					"maxConnections":         float64(cfg.MaxConnections),
 					"cleanupIntervalSeconds": cfg.CleanupIntervalSeconds,
-					"rq": map[string]interface{}{
-						"enabled":      true,
-						"rqDataBits":   cfg.RQDataBits,
-						"rqQueryBits":  cfg.RQQueryBits,
-						"rescore":      cfg.RQRescore,
-						"rescoreLimit": cfg.RescoreLimit,
-					},
+					"rq":                     rqConfig,
 				}
 			}
 			vectorIndexConfig["multivector"] = map[string]interface{}{
@@ -568,31 +591,40 @@ func enableCompression(cfg *Config, client *weaviate.Client, dimensions uint, co
 			segments = uint(math.Pow(2, float64(cfg.MuveraKSim))*float64(cfg.MuveraDProjections)*float64(cfg.MuveraRepetition)) / cfg.PQRatio
 		}
 
-		vectorIndexConfig["pq"] = map[string]interface{}{
+		pqConfig := map[string]interface{}{
 			"enabled":       true,
 			"segments":      segments,
 			"trainingLimit": cfg.TrainingLimit,
-			"rescoreLimit":  cfg.RescoreLimit,
 		}
+		if cfg.RescoreLimit > 0 {
+			pqConfig["rescoreLimit"] = cfg.RescoreLimit
+		}
+		vectorIndexConfig["pq"] = pqConfig
 	case CompressionTypeSQ:
-		vectorIndexConfig["sq"] = map[string]interface{}{
+		sqConfig := map[string]interface{}{
 			"enabled":       true,
 			"trainingLimit": cfg.TrainingLimit,
-			"rescoreLimit":  cfg.RescoreLimit,
 		}
+		if cfg.RescoreLimit > 0 {
+			sqConfig["rescoreLimit"] = cfg.RescoreLimit
+		}
+		vectorIndexConfig["sq"] = sqConfig
 	case CompressionTypeLASQ:
 		vectorIndexConfig["lasq"] = map[string]interface{}{
 			"enabled":       true,
 			"trainingLimit": cfg.TrainingLimit,
 		}
 	case CompressionTypeRQ:
-		vectorIndexConfig["rq"] = map[string]interface{}{
-			"enabled":      true,
-			"dataBits":     cfg.RQDataBits,
-			"queryBits":    cfg.RQQueryBits,
-			"rescore":      cfg.RQRescore,
-			"rescoreLimit": cfg.RescoreLimit,
+		rqConfig := map[string]interface{}{
+			"enabled":   true,
+			"dataBits":  cfg.RQDataBits,
+			"queryBits": cfg.RQQueryBits,
+			"rescore":   cfg.RQRescore,
 		}
+		if cfg.RescoreLimit > 0 {
+			rqConfig["rescoreLimit"] = cfg.RescoreLimit
+		}
+		vectorIndexConfig["rq"] = rqConfig
 	}
 
 	if cfg.MultiVectorDimensions > 0 {
@@ -1276,7 +1308,7 @@ func initAnnBenchmark() {
 	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.Cache,
 		"cache", false, "Set cache")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.RescoreLimit,
-		"rescoreLimit", 256, "Rescore limit (default 256) for BQ. If using RQ, it's recommended to set it to 20")
+		"rescoreLimit", 0, "Rescore limit. If not set, it will be set by Weaviate automatically when rescoring is enabled")
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.PQ,
 		"pq", "disabled", "Set PQ (disabled, auto, or enabled) (default disabled)")
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.SQ,

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -1294,7 +1294,7 @@ func initAnnBenchmark() {
 	annBenchmarkCommand.PersistentFlags().UintVar(&globalConfig.RQQueryBits,
 		"rqQueryBits", 8, "Set RQ query bit (default 8)")
 	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.RQRescore,
-		"rqRescore", false, "Skip rescoring for RQ (default true)")
+		"rqRescore", false, "Skip rescoring for RQ (default true). When enabled, configure it with rescoreLimit")
 	annBenchmarkCommand.PersistentFlags().IntVarP(&globalConfig.MultiVectorDimensions,
 		"multiVector", "m", 0, "Enable multi-dimensional vectors with the specified number of dimensions")
 	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.MuveraEnabled,

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -284,7 +284,7 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 					"dataBits":     cfg.RQDataBits,
 					"queryBits":    cfg.RQQueryBits,
 					"rescore":      cfg.RQRescore,
-					"rescoreLimit": cfg.RQRescoreLimit,
+					"rescoreLimit": cfg.RescoreLimit,
 				},
 			}
 		}
@@ -377,7 +377,7 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 						"rqDataBits":   cfg.RQDataBits,
 						"rqQueryBits":  cfg.RQQueryBits,
 						"rescore":      cfg.RQRescore,
-						"rescoreLimit": cfg.RQRescoreLimit,
+						"rescoreLimit": cfg.RescoreLimit,
 					},
 				}
 			}
@@ -591,7 +591,7 @@ func enableCompression(cfg *Config, client *weaviate.Client, dimensions uint, co
 			"dataBits":     cfg.RQDataBits,
 			"queryBits":    cfg.RQQueryBits,
 			"rescore":      cfg.RQRescore,
-			"rescoreLimit": cfg.RQRescoreLimit,
+			"rescoreLimit": cfg.RescoreLimit,
 		}
 	}
 
@@ -1276,7 +1276,7 @@ func initAnnBenchmark() {
 	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.Cache,
 		"cache", false, "Set cache")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.RescoreLimit,
-		"rescoreLimit", 256, "Rescore limit (default 256) for BQ")
+		"rescoreLimit", 256, "Rescore limit (default 256) for BQ. If using RQ, it's recommended to set it to 20")
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.PQ,
 		"pq", "disabled", "Set PQ (disabled, auto, or enabled) (default disabled)")
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.SQ,
@@ -1295,8 +1295,6 @@ func initAnnBenchmark() {
 		"rqQueryBits", 8, "Set RQ query bit (default 8)")
 	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.RQRescore,
 		"rqRescore", false, "Skip rescoring for RQ (default true)")
-	annBenchmarkCommand.PersistentFlags().UintVar(&globalConfig.RQRescoreLimit,
-		"rqRescoreLimit", 20, "Set RQ rescore limit (default 20)")
 	annBenchmarkCommand.PersistentFlags().IntVarP(&globalConfig.MultiVectorDimensions,
 		"multiVector", "m", 0, "Enable multi-dimensional vectors with the specified number of dimensions")
 	annBenchmarkCommand.PersistentFlags().BoolVar(&globalConfig.MuveraEnabled,

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -51,7 +51,6 @@ type Config struct {
 	RQDataBits               uint
 	RQQueryBits              uint
 	RQRescore                bool
-	RQRescoreLimit           uint
 	SkipQuery                bool
 	SkipAsyncReady           bool
 	SkipTombstonesEmpty      bool


### PR DESCRIPTION
Having the two parameters enabled might be confusing. Either have one RescoreLimit common for all or have specific params for each quantization (BQRescoreLimit, RQRescoreLimit,...), but it makes more sense to only have one.

Additionally, do not set any value if the user does not provide it. That way, Weaviate will set it to its internal defaults.