### PR TITLE
feature: Add SPFresh params

### DIFF
--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -1053,13 +1053,13 @@ func initAnnBenchmark() {
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.Dataset,
 		"dataset", "", "Dataset name e.g. dbpedia-openai-ada002-1536-float32-angular-100k")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.MaxPostingSize,
-		"maxPostingSize", 0, "Max posting size (default 0)")
+		"maxPostingSize", 0, "Max posting size for SPFresh index (default 0)")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.MinPostingSize,
-		"minPostingSize", 10, "Min posting size (default 10)")
+		"minPostingSize", 10, "Min posting size for SPFresh index (default 10)")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.Replicas,
-		"replicas", 8, "Number of replicas (default 8)")
+		"replicas", 8, "Number of replicas for SPFresh index (default 8)")
 	annBenchmarkCommand.PersistentFlags().Float64Var(&globalConfig.RngFactor,
-		"rngFactor", 10.0, "RNG factor (default 10.0)")
+		"rngFactor", 10.0, "RNG factor for SPFresh index (default 10.0)")
 }
 
 func benchmarkANN(cfg Config, queries Queries, neighbors Neighbors, filters []int) Results {

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -347,7 +347,11 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 		}
 	} else if cfg.IndexType == "spfresh" {
 		vectorIndexConfig = map[string]interface{}{
-			"distance": cfg.DistanceMetric,
+			"distance":       cfg.DistanceMetric,
+			"maxPostingSize": cfg.MaxPostingSize,
+			"minPostingSize": cfg.MinPostingSize,
+			"numReplicas":    cfg.NumReplicas,
+			"rngFactor":      cfg.RngFactor,
 		}
 	} else {
 		log.Fatalf("Unknown index type %s", cfg.IndexType)
@@ -1048,6 +1052,14 @@ func initAnnBenchmark() {
 		"datasetRepo", "", "Hugging Face dataset repo e.g. weaviate/ann-datasets")
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.Dataset,
 		"dataset", "", "Dataset name e.g. dbpedia-openai-ada002-1536-float32-angular-100k")
+	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.MaxPostingSize,
+		"maxPostingSize", 0, "Max posting size (default 0)")
+	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.MinPostingSize,
+		"minPostingSize", 10, "Min posting size (default 10)")
+	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.NumReplicas,
+		"numReplicas", 8, "Number of replicas (default 8)")
+	annBenchmarkCommand.PersistentFlags().Float64Var(&globalConfig.RngFactor,
+		"rngFactor", 10.0, "RNG factor (default 10.0)")
 }
 
 func benchmarkANN(cfg Config, queries Queries, neighbors Neighbors, filters []int) Results {

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -350,7 +350,7 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 			"distance":       cfg.DistanceMetric,
 			"maxPostingSize": cfg.MaxPostingSize,
 			"minPostingSize": cfg.MinPostingSize,
-			"numReplicas":    cfg.NumReplicas,
+			"replicas":       cfg.Replicas,
 			"rngFactor":      cfg.RngFactor,
 		}
 	} else {
@@ -1056,8 +1056,8 @@ func initAnnBenchmark() {
 		"maxPostingSize", 0, "Max posting size (default 0)")
 	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.MinPostingSize,
 		"minPostingSize", 10, "Min posting size (default 10)")
-	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.NumReplicas,
-		"numReplicas", 8, "Number of replicas (default 8)")
+	annBenchmarkCommand.PersistentFlags().IntVar(&globalConfig.Replicas,
+		"replicas", 8, "Number of replicas (default 8)")
 	annBenchmarkCommand.PersistentFlags().Float64Var(&globalConfig.RngFactor,
 		"rngFactor", 10.0, "RNG factor (default 10.0)")
 }

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -79,7 +79,7 @@ type Config struct {
 	Dataset                  string
 	MaxPostingSize           int
 	MinPostingSize           int
-	NumReplicas              int
+	Replicas                 int
 	RngFactor                float64
 }
 

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	MemoryMonitoringFile     string
 	DatasetRepo              string
 	Dataset                  string
+	MaxPostingSize           int
+	MinPostingSize           int
+	NumReplicas              int
+	RngFactor                float64
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
## Summary
This PR adds support for configuring SPFresh index parameters through the benchmarker CLI. Users can now customize `maxPostingSize`, `minPostingSize`, `replicas`, and `rngFactor` when running benchmarks with the SPFresh index type.

## Changes
Added four new configuration fields to the Config struct:
- `--maxPostingSize` (int, default: 0) 
- `--minPostingSize` (int, default: 10)
- `--replicas` (int, default: 8)
- `--rngFactor` (float64, default: 10.0)