### PR TITLE
Add metrics endpoint

### DIFF
--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -1099,6 +1099,8 @@ func initAnnBenchmark() {
 		"httpOrigin", "localhost:8080", "The http origin for Weaviate (only used if grpc enabled)")
 	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.HttpScheme,
 		"httpScheme", "http", "The http scheme (http or https)")
+	annBenchmarkCommand.PersistentFlags().StringVar(&globalConfig.MetricsEndpoint,
+		"metricsEndpoint", "http://localhost:2112/metrics", "The metrics endpoint for Weaviate(default http://localhost:2112/metrics)")
 	annBenchmarkCommand.PersistentFlags().StringVarP(&globalConfig.OutputFormat,
 		"format", "f", "text", "Output format, one of [text, json]")
 	annBenchmarkCommand.PersistentFlags().IntVarP(&globalConfig.Limit,

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	StartTenantNum           int
 	NumTenants               int
 	ExistingSchema           bool
+	MetricsEndpoint          string
 	HttpOrigin               string
 	HttpScheme               string
 	UpdatePercentage         float64

--- a/benchmarker/cmd/metrics.go
+++ b/benchmarker/cmd/metrics.go
@@ -18,7 +18,7 @@ type Memstats struct {
 }
 
 func readMemoryMetrics(cfg *Config) (*Memstats, error) {
-	prometheusURL := fmt.Sprintf("http://%s/metrics", strings.Replace(cfg.HttpOrigin, "8080", "2112", -1))
+	prometheusURL := cfg.MetricsEndpoint
 	response, err := http.Get(prometheusURL)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ type HFreshPendingMetrics struct {
 }
 
 func readHFreshMetrics(cfg *Config) (*HFreshPendingMetrics, error) {
-	prometheusURL := fmt.Sprintf("http://%s/metrics", strings.Replace(cfg.HttpOrigin, "8080", "2112", -1))
+	prometheusURL := cfg.MetricsEndpoint
 	response, err := http.Get(prometheusURL)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func readHFreshMetrics(cfg *Config) (*HFreshPendingMetrics, error) {
 
 func waitTombstonesEmpty(cfg *Config) error {
 
-	prometheusURL := fmt.Sprintf("http://%s/metrics", strings.Replace(cfg.HttpOrigin, "8080", "2112", -1))
+	prometheusURL := cfg.MetricsEndpoint
 	metricName := "vector_index_tombstones"
 
 	log.Printf("Waiting to allow for tombstone cleanup\n")


### PR DESCRIPTION
Instead of hardcoded http Schema and port, let the user configure the full metrics endpoint.

This is useful for WCD runs.