### PR TITLE
Use Debian as base image for docker build

### DIFF
--- a/benchmarker/Dockerfile
+++ b/benchmarker/Dockerfile
@@ -1,12 +1,35 @@
-FROM golang:1.24-alpine AS builder
-RUN apk add --no-cache build-base hdf5-dev gcc libc-dev python3 bash g++ musl-dev make cmake
+### BUILDER STAGE ###
+FROM golang:1.24-bookworm AS builder
+# or: FROM golang:1.24-ubuntu24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libhdf5-dev \
+    python3 \
+    bash \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . .
+
+# Enable CGO so HDF5 links correctly
 RUN CGO_ENABLED=1 go build -o benchmarker .
 
-FROM golang:1.24-alpine
-RUN apk add --no-cache hdf5-dev python3 bash
+
+### RUNTIME STAGE ###
+FROM debian:bookworm-slim
+# or: FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libhdf5-103 \
+    python3 \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY --from=builder /app/benchmarker /app/benchmarker
 COPY --from=builder /app/scripts/ /app/scripts/
+
 CMD ["/app/benchmarker"]


### PR DESCRIPTION
Alpine was problematic to build the benchmarker due to the usage of hdf5 library.

Using Debian is more resilient to make that build