### PR TITLE
Integration tests

### DIFF
--- a/benchmarker/CLAUDE.md
+++ b/benchmarker/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a multi-threaded benchmarking CLI for Weaviate (a vector database), written in Go. It measures query performance, throughput, recall, and memory usage across various benchmark scenarios. It supports gRPC and GraphQL APIs and works with HDF5 datasets in ann-benchmarks.com format.
+
+## Build & Run
+
+**Prerequisite:** HDF5 library must be installed (`brew install hdf5` on macOS, `apt install libhdf5-dev` on Linux). CGO is required.
+
+```bash
+# Run directly (no compile step)
+go run . help
+go run . ann-benchmark -v ~/datasets/dataset.hdf5 -d l2-squared
+
+# Compile and install
+CGO_ENABLED=1 go install .
+
+# Docker
+docker build -t weaviate-benchmarker .
+```
+
+## Tests
+
+```bash
+# Unit tests (no Weaviate required)
+go test ./cmd/...
+go test -v -run TestAnalyzer ./cmd/...   # run a specific test
+
+# Integration tests (require Weaviate at localhost:8080 / localhost:50051)
+docker run -p 8080:8080 -p 50051:50051 semitechnologies/weaviate:latest
+go test -tags integration ./cmd/...
+go test -tags integration -v -run TestIntegration_RecallForExactNeighbors ./cmd/...
+```
+
+Unit tests live in `cmd/benchmark_run_test.go` and cover UUID conversions, NDCG calculation, and results analysis. Integration tests live in `cmd/integration_test.go` and exercise the full insert→query cycle against a real Weaviate instance; they skip automatically if Weaviate is not reachable.
+
+## Architecture
+
+The CLI is built with Cobra. Entry point is `main.go` → `cmd.Execute()`.
+
+**Commands** (each in its own file in `cmd/`):
+- `ann-benchmark` — primary command; loads an HDF5 dataset into Weaviate, then queries it
+- `random-vectors` — queries with randomly generated vectors
+- `random-text` — queries with random text
+- `raw` — executes raw GraphQL queries
+- `dataset` — loads from dataset repositories
+- `colbert` — multi-vector (ColBERT) search
+
+**Core execution flow** (`cmd/benchmark_run.go`):
+1. Parse flags → build `Config`
+2. Create Weaviate client (gRPC or HTTP)
+3. Load dataset via `Dataset` interface (HDF5 or Parquet) using a producer-consumer pipeline with 8 worker goroutines writing batches
+4. Wait for async indexing to complete
+5. Distribute test queries across a parallel worker pool
+6. Collect latencies, compute recall/NDCG against ground truth neighbors
+7. Output results as text or JSON; optionally write memory metrics
+
+**Key files:**
+| File | Role |
+|------|------|
+| `cmd/config.go` | `Config` struct and all flag definitions |
+| `cmd/ann_benchmark.go` | `ann-benchmark` command — dataset loading orchestration |
+| `cmd/benchmark_run.go` | Core query execution, metrics collection, recall/NDCG |
+| `cmd/load_data.go` | Data loading pipeline (batching, compression setup) |
+| `cmd/hdf5_dataset.go` | HDF5 file I/O via `Dataset` interface |
+| `cmd/metrics.go` | Prometheus scraping for Weaviate memory stats |
+| `cmd/memory_monitor.go` | Background goroutine for periodic memory snapshots |
+
+**Dataset interface** (`cmd/dataset_interface.go`): abstracts over HDF5, Parquet, and other formats. Implement this interface to add a new dataset source.
+
+## Configuration
+
+All flags are defined in `cmd/config.go`. Key ones for `ann-benchmark`:
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `-v` / `--vectors` | — | Path to HDF5 file (required) |
+| `-d` / `--distance` | — | Distance metric, e.g. `cosine`, `l2-squared` (required) |
+| `-u` / `--origin` | `localhost:50051` | gRPC endpoint |
+| `--httpOrigin` | `localhost:8080` | HTTP endpoint |
+| `-a` / `--api` | `grpc` | `grpc` or `graphql` |
+| `-p` / `--parallel` | `8` | Worker threads |
+| `-l` / `--limit` | `10` | Top-k results |
+| `--pq` / `--sq` / `--rq` | `disabled` | Compression: `disabled`, `auto`, or `enabled` |
+| `--efConstruction` | `256` | HNSW build parameter |
+| `--maxConnections` | `16` | HNSW build parameter |
+| `--queryDuration` | `0` | Run queries for N seconds instead of one pass |
+| `--updatePercentage` | `0` | Percentage of vectors to update after loading |
+| `--numTenants` | `0` | Multi-tenancy: number of tenants |
+
+## Automated Benchmark Plans
+
+`plan_runner.py` drives multi-run benchmarks using `plan.yml` (see `plan.yml.example`). It checks out branches of the Weaviate repo, starts/stops Weaviate, and runs the benchmarker for each configuration.
+
+## Python Scripts
+
+`scripts/python/` contains analysis tools:
+- `memory_analysis.py` — visualize memory metrics from JSON output
+- `collate-results.py` — aggregate results across multiple runs
+- `ann.py` — ANN benchmark runner wrapper
+- `performance-graphs.py` — generate performance comparison graphs
+
+Install Python dependencies: `pip install -r requirements.txt`

--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -151,16 +151,16 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 			ids = append(ids, intFromUUID(result.GetMetadata().Id))
 		}
 
-		neighborLimit := min(cfg.Limit, len(query.Neighbors))
-		recallQuery := float64(len(intersection(ids, query.Neighbors[:neighborLimit]))) / float64(neighborLimit)
-		ndcgQuery := calculateLinearNDCG(ids, query.Neighbors, neighborLimit)
-
-		log.Debugf("Query took %s, recall %f, ndcg %f", took, recallQuery, ndcgQuery)
-
 		m.Lock()
 		*times = append(*times, took)
-		*recall = append(*recall, recallQuery)
-		*ndcg = append(*ndcg, ndcgQuery)
+		if len(query.Neighbors) > 0 {
+			neighborLimit := min(cfg.Limit, len(query.Neighbors))
+			recallQuery := float64(len(intersection(ids, query.Neighbors[:neighborLimit]))) / float64(neighborLimit)
+			ndcgQuery := calculateLinearNDCG(ids, query.Neighbors, neighborLimit)
+			log.Debugf("Query took %s, recall %f, ndcg %f", took, recallQuery, ndcgQuery)
+			*recall = append(*recall, recallQuery)
+			*ndcg = append(*ndcg, ndcgQuery)
+		}
 		m.Unlock()
 	}
 }
@@ -281,8 +281,12 @@ func analyze(cfg Config, times []time.Duration, total time.Duration, recall []fl
 	out.Mean = sum / time.Duration(len(times))
 	out.Took = total
 	out.QueriesPerSecond = float64(len(times)) / float64(float64(total)/float64(time.Second))
-	out.Recall = sumRecall / float64(len(recall))
-	out.NDCG = sumNDCG / float64(len(ndcg))
+	if len(recall) > 0 {
+		out.Recall = sumRecall / float64(len(recall))
+	}
+	if len(ndcg) > 0 {
+		out.NDCG = sumNDCG / float64(len(ndcg))
+	}
 
 	sort.Slice(times, func(a, b int) bool {
 		return times[a] < times[b]

--- a/benchmarker/cmd/integration_test.go
+++ b/benchmarker/cmd/integration_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+package cmd
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"google.golang.org/grpc"
+)
+
+const (
+	integrationClassName   = "BenchmarkIntTest"
+	integrationDimensions  = 16
+	integrationVectorCount = 300
+)
+
+func integrationCfg() Config {
+	return Config{
+		Origin:                 "localhost:50051",
+		HttpOrigin:             "localhost:8080",
+		HttpScheme:             "http",
+		API:                    "grpc",
+		ClassName:              integrationClassName,
+		Dimensions:             integrationDimensions,
+		Parallel:               4,
+		Queries:                50,
+		Limit:                  10,
+		DistanceMetric:         "cosine",
+		EfConstruction:         64,
+		MaxConnections:         16,
+		BatchSize:              100,
+		IndexType:              "hnsw",
+		Mode:                   "ann-benchmark",
+		OutputFormat:           "text",
+		RescoreLimit:           -1,
+		CleanupIntervalSeconds: 300,
+		FlatSearchCutoff:       40000,
+	}
+}
+
+// skipIfWeaviateUnavailable skips the test if Weaviate is not reachable.
+// Start a local instance with:
+//
+//	docker run -p 8080:8080 -p 50051:50051 semitechnologies/weaviate:latest
+func skipIfWeaviateUnavailable(t *testing.T, origin string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, origin, grpc.WithInsecure(), grpc.WithBlock()) //nolint:staticcheck
+	if err != nil {
+		t.Skipf("Weaviate not available at %s: %v", origin, err)
+	}
+	conn.Close()
+}
+
+// generateVectors creates n deterministic random float32 vectors of the given dimension.
+func generateVectors(n, dims int, seed int64) [][]float32 {
+	rng := rand.New(rand.NewSource(seed))
+	vecs := make([][]float32, n)
+	for i := range vecs {
+		v := make([]float32, dims)
+		for j := range v {
+			v[j] = rng.Float32()*2 - 1
+		}
+		vecs[i] = v
+	}
+	return vecs
+}
+
+// setupTestCollection creates a fresh collection, inserts the given vectors via
+// gRPC, and registers a t.Cleanup to delete the collection after the test.
+func setupTestCollection(t *testing.T, cfg *Config, vectors [][]float32) {
+	t.Helper()
+	client := createClient(cfg)
+
+	// Delete first (ignore error — collection may not exist yet).
+	_ = client.Schema().ClassDeleter().WithClassName(cfg.ClassName).Do(context.Background())
+
+	classObj := &models.Class{
+		Class:           cfg.ClassName,
+		VectorIndexType: "hnsw",
+		VectorIndexConfig: map[string]interface{}{
+			"distance":               cfg.DistanceMetric,
+			"efConstruction":         float64(cfg.EfConstruction),
+			"maxConnections":         float64(cfg.MaxConnections),
+			"cleanupIntervalSeconds": cfg.CleanupIntervalSeconds,
+			"flatSearchCutoff":       cfg.FlatSearchCutoff,
+		},
+	}
+	err := client.Schema().ClassCreator().WithClass(classObj).Do(context.Background())
+	require.NoError(t, err, "create collection %q", cfg.ClassName)
+
+	t.Cleanup(func() {
+		_ = client.Schema().ClassDeleter().WithClassName(cfg.ClassName).Do(context.Background())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, cfg.Origin, grpc.WithInsecure()) //nolint:staticcheck
+	require.NoError(t, err)
+	defer conn.Close()
+	grpcClient := weaviategrpc.NewWeaviateClient(conn)
+
+	writeChunk(&Batch{Vectors: vectors, Offset: 0}, &grpcClient, cfg)
+
+	// Give HNSW time to finish indexing before querying.
+	time.Sleep(3 * time.Second)
+}
+
+// TestIntegration_QueriesSucceed runs a full insert→query cycle with random
+// query vectors and asserts that no queries fail and throughput is positive.
+func TestIntegration_QueriesSucceed(t *testing.T) {
+	cfg := integrationCfg()
+	skipIfWeaviateUnavailable(t, cfg.Origin)
+
+	vectors := generateVectors(integrationVectorCount, integrationDimensions, 42)
+	setupTestCollection(t, &cfg, vectors)
+
+	results := benchmark(cfg, func(_ string) QueryWithNeighbors {
+		return QueryWithNeighbors{
+			Query: nearVectorQueryGrpc(&cfg, randomVector(cfg.Dimensions), "", -1),
+		}
+	})
+
+	assert.Equal(t, 0, results.Failed, "expected zero failed queries")
+	assert.Equal(t, cfg.Queries, results.Successful, "all queries should succeed")
+	assert.Greater(t, results.QueriesPerSecond, 0.0, "QPS should be positive")
+	assert.Greater(t, int64(results.Mean), int64(0), "mean latency should be positive")
+	assert.GreaterOrEqual(t, results.Max, results.Mean, "max latency must be >= mean")
+	assert.LessOrEqual(t, results.Min, results.Mean, "min latency must be <= mean")
+}
+
+// TestIntegration_RecallForExactNeighbors inserts a known set of vectors and
+// then queries with exact copies of those vectors. Because each query vector is
+// already in the index its distance to itself is 0, so it must be the top result.
+// Recall should be ≥ 0.9 even at low ef values.
+func TestIntegration_RecallForExactNeighbors(t *testing.T) {
+	cfg := integrationCfg()
+	cfg.Queries = 50
+	cfg.Limit = 1 // top-1: the exact match must appear
+	skipIfWeaviateUnavailable(t, cfg.Origin)
+
+	vectors := generateVectors(integrationVectorCount, integrationDimensions, 99)
+	setupTestCollection(t, &cfg, vectors)
+
+	// getQueryFn is called sequentially inside benchmark() before workers start,
+	// so queryIdx is not accessed concurrently.
+	queryIdx := 0
+	results := benchmark(cfg, func(_ string) QueryWithNeighbors {
+		i := queryIdx % len(vectors)
+		queryIdx++
+		return QueryWithNeighbors{
+			Query:     nearVectorQueryGrpc(&cfg, vectors[i], "", -1),
+			Neighbors: []int{i}, // ground truth: the vector itself is its nearest neighbour
+		}
+	})
+
+	assert.Equal(t, 0, results.Failed, "expected zero failed queries")
+	assert.Greater(t, results.Recall, 0.9, "recall must be >90%% for exact vector matches")
+}
+
+// TestIntegration_ResultsJSON checks that the JSON output of a real benchmark
+// round-trip is well-formed and contains the expected top-level keys.
+func TestIntegration_ResultsJSON(t *testing.T) {
+	cfg := integrationCfg()
+	cfg.Queries = 20
+	cfg.OutputFormat = "json"
+	skipIfWeaviateUnavailable(t, cfg.Origin)
+
+	vectors := generateVectors(integrationVectorCount, integrationDimensions, 7)
+	setupTestCollection(t, &cfg, vectors)
+
+	results := benchmark(cfg, func(_ string) QueryWithNeighbors {
+		return QueryWithNeighbors{
+			Query: nearVectorQueryGrpc(&cfg, randomVector(cfg.Dimensions), "", -1),
+		}
+	})
+
+	// Verify the JSON serialiser doesn't error and produces non-empty output.
+	var buf strings.Builder
+	n, err := results.WriteJSONTo(&buf)
+	require.NoError(t, err)
+	assert.Greater(t, n, 0, "JSON output should not be empty")
+
+	// Basic sanity: the output should contain throughput and metadata keys.
+	out := buf.String()
+	assert.Contains(t, out, `"qps"`)
+	assert.Contains(t, out, `"successful"`)
+	assert.Contains(t, out, `"recall"`)
+}


### PR DESCRIPTION
  Summary

  Adds integration tests that exercise the full insert→query cycle against a real Weaviate instance, covering paths that unit tests couldn't reach (data loading, gRPC querying, recall computation, JSON serialisation).

  In writing the tests, a pre-existing bug was found and fixed: when no ground truth neighbors are provided (e.g. random-vectors mode), neighborLimit is 0, causing a 0.0/0.0 float division that produces NaN. That NaN then propagates into JSON
  output and crashes serialisation with json: unsupported value: NaN.

  Changes

  cmd/integration_test.go — three tests gated behind //go:build integration:
  - TestIntegration_QueriesSucceed — inserts 300 vectors, runs 50 random-vector queries, asserts zero failures and positive QPS/latency.
  - TestIntegration_RecallForExactNeighbors — queries with exact copies of inserted vectors (ground truth = the vector itself), asserts recall > 90%.
  - TestIntegration_ResultsJSON — runs a real query cycle and verifies the JSON serialiser produces well-formed output with the expected keys.

  Tests skip automatically if Weaviate is not reachable, so a plain go test ./cmd/... is unaffected.

  cmd/benchmark_run.go — bug fix for NaN recall/NDCG:
  - processQueueGrpc: skip recall/NDCG computation when query.Neighbors is empty instead of dividing by zero.
  - analyze: guard mean recall/NDCG against empty slices, returning 0 instead of NaN.

  benchmarker/CLAUDE.md — new file documenting build commands, architecture, and how to run both unit and integration tests.

  How to run the integration tests

  docker run -p 8080:8080 -p 50051:50051 semitechnologies/weaviate:latest
  go test -tags integration ./cmd/...