### PR TITLE
Add search_probe label and tests for metrics-exporter

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,9 +25,16 @@ jobs:
           cache-dependency-path: benchmarker/go.sum
       - name: Install hdf5
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential libhdf5-dev
-      - name: Run tests
+      - name: Run benchmarker tests
         working-directory: benchmarker
         run: CGO_ENABLED=1 go test ./...
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: metrics-exporter/go.mod
+          cache-dependency-path: metrics-exporter/go.sum
+      - name: Run metrics-exporter tests
+        working-directory: metrics-exporter
+        run: go test ./...
 
   Push-Docker:
     name: push-docker

--- a/metrics-exporter/component_test.go
+++ b/metrics-exporter/component_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestPollDirectoryPublishesLatestFile(t *testing.T) {
+	dir := t.TempDir()
+	reg := prometheus.NewRegistry()
+	exporter := NewExporter()
+	exporter.initializeMetrics(reg)
+
+	older := filepath.Join(dir, "older.json")
+	newer := filepath.Join(dir, "newer.json")
+	if err := os.WriteFile(older, []byte(`[{"branch":"old","dataset_file":"a.hdf5","ef":1,"efConstruction":1,"limit":1,"maxConnections":1,"meanLatency":1,"test_id":"old"}]`), 0o644); err != nil {
+		t.Fatalf("write older: %v", err)
+	}
+	if err := os.WriteFile(newer, []byte(`[{"branch":"new","dataset_file":"b.hdf5","ef":2,"efConstruction":2,"limit":2,"maxConnections":2,"meanLatency":2,"test_id":"new"}]`), 0o644); err != nil {
+		t.Fatalf("write newer: %v", err)
+	}
+
+	now := time.Now()
+	if err := os.Chtimes(older, now.Add(-time.Hour), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("chtimes older: %v", err)
+	}
+	if err := os.Chtimes(newer, now, now); err != nil {
+		t.Fatalf("chtimes newer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go pollDirectory(ctx, dir, exporter, 25*time.Millisecond)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.Write([]byte(`<a href="/metrics">Metrics</a>`))
+		case "/metrics":
+			promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	deadline := time.Now().Add(2 * time.Second)
+	var body string
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(srv.URL + "/metrics")
+		if err == nil {
+			payload, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr == nil && resp.StatusCode == http.StatusOK {
+				body = string(payload)
+				if strings.Contains(body, `branch="new"`) && strings.Contains(body, "benchmark_latency_mean") {
+					break
+				}
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	if !strings.Contains(body, `branch="new"`) {
+		t.Fatalf("metrics never picked up newest file\nbody:\n%s", body)
+	}
+	if strings.Contains(body, `branch="old"`) {
+		t.Fatalf("metrics still contain stale branch=old\nbody:\n%s", body)
+	}
+}

--- a/metrics-exporter/exporter_test.go
+++ b/metrics-exporter/exporter_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func newTestExporter(t *testing.T) (*Exporter, *prometheus.Registry) {
+	t.Helper()
+
+	reg := prometheus.NewRegistry()
+	exporter := NewExporter()
+	exporter.initializeMetrics(reg)
+	return exporter, reg
+}
+
+func writeJSONFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	return path
+}
+
+func touchFile(t *testing.T, path string, modTime time.Time) {
+	t.Helper()
+
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}
+
+func TestPrometheusLabelsDefaults(t *testing.T) {
+	labels := prometheusLabels(MetricData{DatasetFile: "x.hdf5"})
+	if labels["branch"] != "main" {
+		t.Fatalf("branch = %q, want main", labels["branch"])
+	}
+	if labels["test_id"] != "NA" {
+		t.Fatalf("test_id = %q, want NA", labels["test_id"])
+	}
+}
+
+func TestPrometheusLabelsPreservesValues(t *testing.T) {
+	labels := prometheusLabels(MetricData{
+		Branch:         "release",
+		DatasetFile:    "data.hdf5",
+		EFConstruction: 256,
+		MaxConnections: 32,
+		Limit:          10,
+		EF:             16,
+		SearchProbe:    8,
+		Shards:         2,
+		TestID:         "run-42",
+	})
+
+	want := map[string]string{
+		"branch":          "release",
+		"dataset":         "data.hdf5",
+		"ef_construction": "256",
+		"max_connections": "32",
+		"limit":           "10",
+		"ef":              "16",
+		"search_probe":    "8",
+		"shards":          "2",
+		"test_id":         "run-42",
+	}
+	for key, value := range want {
+		if labels[key] != value {
+			t.Fatalf("label %s = %q, want %q", key, labels[key], value)
+		}
+	}
+}
+
+func TestFindLatestJSONFile(t *testing.T) {
+	dir := t.TempDir()
+
+	olderPath := writeJSONFile(t, dir, "older.json", `[]`)
+	newerPath := writeJSONFile(t, dir, "newer.json", `[]`)
+	writeJSONFile(t, dir, "notes.txt", `not json`)
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	touchFile(t, olderPath, base)
+	touchFile(t, newerPath, base.Add(time.Hour))
+
+	got, err := findLatestJSONFile(dir)
+	if err != nil {
+		t.Fatalf("findLatestJSONFile: %v", err)
+	}
+	if got != newerPath {
+		t.Fatalf("latest file = %q, want %q", got, newerPath)
+	}
+}
+
+func TestFindLatestJSONFileAwaitingResults(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := findLatestJSONFile(dir)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "awaiting results") {
+		t.Fatalf("error = %q, want awaiting results", err.Error())
+	}
+}
+
+func TestFindLatestJSONFileWalkError(t *testing.T) {
+	_, err := findLatestJSONFile(filepath.Join(t.TempDir(), "missing-subdir", "nope"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestProcessJSONFile(t *testing.T) {
+	exporter, reg := newTestExporter(t)
+
+	fixture := filepath.Join("testdata", "sample_results.json")
+	if err := exporter.processJSONFile(fixture); err != nil {
+		t.Fatalf("processJSONFile: %v", err)
+	}
+
+	labels := map[string]string{
+		"branch":          "feature-branch",
+		"dataset":         "sample.hdf5",
+		"ef_construction": "256",
+		"max_connections": "32",
+		"limit":           "10",
+		"ef":              "16",
+		"search_probe":    "8",
+		"shards":          "2",
+		"test_id":         "run-001",
+	}
+	if got := gaugeValue(t, reg, "benchmark_latency_mean", labels); got != 0.01 {
+		t.Fatalf("latency_mean = %v, want 0.01", got)
+	}
+	if got := gaugeValue(t, reg, "benchmark_qps", labels); got != 1000 {
+		t.Fatalf("qps = %v, want 1000", got)
+	}
+
+	defaultLabels := map[string]string{
+		"branch":          "main",
+		"dataset":         "defaults.hdf5",
+		"ef_construction": "128",
+		"max_connections": "16",
+		"limit":           "5",
+		"ef":              "24",
+		"search_probe":    "0",
+		"shards":          "1",
+		"test_id":         "NA",
+	}
+	if got := gaugeValue(t, reg, "benchmark_latency_mean", defaultLabels); got != 0.02 {
+		t.Fatalf("default latency_mean = %v, want 0.02", got)
+	}
+}
+
+func TestProcessJSONFileResetsStaleSeries(t *testing.T) {
+	exporter, reg := newTestExporter(t)
+	dir := t.TempDir()
+
+	first := writeJSONFile(t, dir, "first.json", `[
+		{
+			"branch": "only-once",
+			"dataset_file": "gone.hdf5",
+			"ef": 1,
+			"efConstruction": 1,
+			"limit": 1,
+			"maxConnections": 1,
+			"meanLatency": 1,
+			"test_id": "t1"
+		}
+	]`)
+	second := writeJSONFile(t, dir, "second.json", `[
+		{
+			"branch": "replacement",
+			"dataset_file": "stay.hdf5",
+			"ef": 2,
+			"efConstruction": 2,
+			"limit": 2,
+			"maxConnections": 2,
+			"meanLatency": 2,
+			"test_id": "t2"
+		}
+	]`)
+	touchFile(t, first, time.Now().Add(-time.Hour))
+	touchFile(t, second, time.Now())
+
+	if err := exporter.processJSONFile(first); err != nil {
+		t.Fatalf("process first file: %v", err)
+	}
+	if err := exporter.processJSONFile(second); err != nil {
+		t.Fatalf("process second file: %v", err)
+	}
+
+	staleLabels := map[string]string{
+		"branch":          "only-once",
+		"dataset":         "gone.hdf5",
+		"ef_construction": "1",
+		"max_connections": "1",
+		"limit":           "1",
+		"ef":              "1",
+		"search_probe":    "0",
+		"shards":          "0",
+		"test_id":         "t1",
+	}
+	if _, ok := gaugeValueOK(reg, "benchmark_latency_mean", staleLabels); ok {
+		t.Fatal("expected stale series to be removed after reset")
+	}
+}
+
+func TestProcessJSONFileErrors(t *testing.T) {
+	exporter, _ := newTestExporter(t)
+
+	if err := exporter.processJSONFile(filepath.Join(t.TempDir(), "missing.json")); !errors.Is(err, os.ErrNotExist) && !strings.Contains(err.Error(), "error reading file") {
+		t.Fatalf("missing file error = %v", err)
+	}
+
+	badJSON := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(badJSON, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write bad json: %v", err)
+	}
+	if err := exporter.processJSONFile(badJSON); err == nil || !strings.Contains(err.Error(), "error parsing JSON") {
+		t.Fatalf("bad json error = %v", err)
+	}
+}
+
+func TestMetricsHTTPServe(t *testing.T) {
+	exporter, reg := newTestExporter(t)
+
+	fixture := filepath.Join("testdata", "sample_results.json")
+	if err := exporter.processJSONFile(fixture); err != nil {
+		t.Fatalf("processJSONFile: %v", err)
+	}
+
+	srv := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"benchmark_latency_mean",
+		`branch="feature-branch"`,
+		`dataset="sample.hdf5"`,
+		"benchmark_qps",
+		"benchmark_recall",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("metrics body missing %q\nbody:\n%s", want, text)
+		}
+	}
+}
+
+func gaugeValueOK(reg *prometheus.Registry, name string, labels map[string]string) (float64, bool) {
+	mfs, err := reg.Gather()
+	if err != nil {
+		return 0, false
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if labelsMatch(metric.GetLabel(), labels) {
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+
+	value, ok := gaugeValueOK(reg, name, labels)
+	if !ok {
+		t.Fatalf("metric %s with labels %#v not found", name, labels)
+	}
+	return value
+}
+
+func labelsMatch(metricLabels []*dto.LabelPair, want map[string]string) bool {
+	if len(metricLabels) != len(want) {
+		return false
+	}
+	for _, pair := range metricLabels {
+		if want[pair.GetName()] != pair.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/metrics-exporter/main.go
+++ b/metrics-exporter/main.go
@@ -24,6 +24,7 @@ type MetricData struct {
 	Branch         string  `json:"branch"`
 	DatasetFile    string  `json:"dataset_file"`
 	EF             int     `json:"ef"`
+	SearchProbe    int     `json:"searchProbe"`
 	EFConstruction int     `json:"efConstruction"`
 	Limit          int     `json:"limit"`
 	MaxConnections int     `json:"maxConnections"`
@@ -50,7 +51,7 @@ func NewExporter() *Exporter {
 }
 
 func (e *Exporter) initializeMetrics() {
-	labels := []string{"branch", "dataset", "ef_construction", "max_connections", "limit", "ef", "shards", "test_id"}
+	labels := []string{"branch", "dataset", "ef_construction", "max_connections", "limit", "ef", "search_probe", "shards", "test_id"}
 
 	metricNames := []struct {
 		name string
@@ -111,6 +112,7 @@ func (e *Exporter) processJSONFile(filepath string) error {
 			"max_connections": fmt.Sprintf("%d", data.MaxConnections),
 			"limit":           fmt.Sprintf("%d", data.Limit),
 			"ef":              fmt.Sprintf("%d", data.EF),
+			"search_probe":    fmt.Sprintf("%d", data.SearchProbe),
 			"shards":          fmt.Sprintf("%d", data.Shards),
 			"test_id":         data.TestID,
 		}

--- a/metrics-exporter/main.go
+++ b/metrics-exporter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -50,8 +51,9 @@ func NewExporter() *Exporter {
 	}
 }
 
-func (e *Exporter) initializeMetrics() {
+func (e *Exporter) initializeMetrics(registerer prometheus.Registerer) {
 	labels := []string{"branch", "dataset", "ef_construction", "max_connections", "limit", "ef", "search_probe", "shards", "test_id"}
+	factory := promauto.With(registerer)
 
 	metricNames := []struct {
 		name string
@@ -69,7 +71,7 @@ func (e *Exporter) initializeMetrics() {
 	}
 
 	for _, metric := range metricNames {
-		e.metrics[metric.name] = promauto.NewGaugeVec(
+		e.metrics[metric.name] = factory.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      metric.name,
@@ -77,6 +79,26 @@ func (e *Exporter) initializeMetrics() {
 			},
 			labels,
 		)
+	}
+}
+
+func prometheusLabels(data MetricData) prometheus.Labels {
+	if data.Branch == "" {
+		data.Branch = "main"
+	}
+	if data.TestID == "" {
+		data.TestID = "NA"
+	}
+	return prometheus.Labels{
+		"branch":          data.Branch,
+		"dataset":         data.DatasetFile,
+		"ef_construction": fmt.Sprintf("%d", data.EFConstruction),
+		"max_connections": fmt.Sprintf("%d", data.MaxConnections),
+		"limit":           fmt.Sprintf("%d", data.Limit),
+		"ef":              fmt.Sprintf("%d", data.EF),
+		"search_probe":    fmt.Sprintf("%d", data.SearchProbe),
+		"shards":          fmt.Sprintf("%d", data.Shards),
+		"test_id":         data.TestID,
 	}
 }
 
@@ -97,25 +119,7 @@ func (e *Exporter) processJSONFile(filepath string) error {
 
 	// Update metrics with new values
 	for _, data := range metricsData {
-		if data.Branch == "" {
-			data.Branch = "main"
-		}
-
-		if data.TestID == "" {
-			data.TestID = "NA"
-		}
-
-		labels := prometheus.Labels{
-			"branch":          data.Branch,
-			"dataset":         data.DatasetFile,
-			"ef_construction": fmt.Sprintf("%d", data.EFConstruction),
-			"max_connections": fmt.Sprintf("%d", data.MaxConnections),
-			"limit":           fmt.Sprintf("%d", data.Limit),
-			"ef":              fmt.Sprintf("%d", data.EF),
-			"search_probe":    fmt.Sprintf("%d", data.SearchProbe),
-			"shards":          fmt.Sprintf("%d", data.Shards),
-			"test_id":         data.TestID,
-		}
+		labels := prometheusLabels(data)
 
 		if metric := e.metrics["latency_mean"]; metric != nil {
 			metric.With(labels).Set(data.MeanLatency)
@@ -175,13 +179,19 @@ func findLatestJSONFile(dirPath string) (string, error) {
 	return latestFile, nil
 }
 
-func pollDirectory(dirPath string, exporter *Exporter) {
-	ticker := time.NewTicker(10 * time.Second)
+func pollDirectory(ctx context.Context, dirPath string, exporter *Exporter, interval time.Duration) {
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	var lastProcessedFile string
 
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
 		latestFile, err := findLatestJSONFile(dirPath)
 		if err != nil {
 			log.Printf("Unable to public metrics: %v", err)
@@ -214,10 +224,10 @@ func main() {
 
 			prometheus.Unregister(prometheus.NewGoCollector())
 			exporter := NewExporter()
-			exporter.initializeMetrics()
+			exporter.initializeMetrics(prometheus.DefaultRegisterer)
 
 			// Start polling directory
-			go pollDirectory(dirPath, exporter)
+			go pollDirectory(cmd.Context(), dirPath, exporter, 10*time.Second)
 
 			// Set up HTTP server
 			http.Handle("/metrics", promhttp.Handler())

--- a/metrics-exporter/testdata/sample_results.json
+++ b/metrics-exporter/testdata/sample_results.json
@@ -1,0 +1,39 @@
+[
+  {
+    "api": "grpc",
+    "branch": "feature-branch",
+    "dataset_file": "sample.hdf5",
+    "ef": 16,
+    "searchProbe": 8,
+    "efConstruction": 256,
+    "limit": 10,
+    "maxConnections": 32,
+    "meanLatency": 0.01,
+    "p99Latency": 0.05,
+    "qps": 1000,
+    "recall": 0.9,
+    "shards": 2,
+    "importTime": 42.5,
+    "heap_alloc_bytes": 100,
+    "heap_inuse_bytes": 200,
+    "heap_sys_bytes": 300,
+    "test_id": "run-001"
+  },
+  {
+    "api": "grpc",
+    "dataset_file": "defaults.hdf5",
+    "ef": 24,
+    "efConstruction": 128,
+    "limit": 5,
+    "maxConnections": 16,
+    "meanLatency": 0.02,
+    "p99Latency": 0.06,
+    "qps": 500,
+    "recall": 0.8,
+    "shards": 1,
+    "importTime": 10,
+    "heap_alloc_bytes": 50,
+    "heap_inuse_bytes": 60,
+    "heap_sys_bytes": 70
+  }
+]


### PR DESCRIPTION
## Summary

- Exposes `searchProbe` from benchmark results as the `search_probe` Prometheus label on all exporter metrics.
- Adds unit tests (JSON parsing, label defaults, latest-file selection, metric reset) and a component test that verifies directory polling publishes the newest results to `/metrics`.
- Runs `go test ./...` for `metrics-exporter` in CI.

## Test plan

- [x] `cd metrics-exporter && go test ./...`
- [x] CI green on this PR
