### PR TITLE
Make namedVector compose with multivector in ann-benchmark

### DIFF
--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -121,21 +121,22 @@ func writeChunk(chunk *Batch, client *weaviategrpc.WeaviateClient, cfg *Config) 
 				end := start + cfg.MultiVectorDimensions
 				multiVec[i] = vector[start:end]
 			}
+			name := "multivector"
+			if cfg.NamedVector != "" {
+				name = cfg.NamedVector
+			}
 			objects[i].Vectors = []*weaviategrpc.Vectors{{
-				Name:        "multivector",
+				Name:        name,
 				VectorBytes: byteops.Fp32SliceOfSlicesToBytes(multiVec),
 				Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
 			}}
+		} else if cfg.NamedVector != "" {
+			objects[i].Vectors = []*weaviategrpc.Vectors{{
+				Name:        cfg.NamedVector,
+				VectorBytes: encodeVector(vector),
+			}}
 		} else {
 			objects[i].VectorBytes = encodeVector(vector)
-		}
-		if cfg.NamedVector != "" {
-			vectors := make([]*weaviategrpc.Vectors, 1)
-			vectors[0] = &weaviategrpc.Vectors{
-				VectorBytes: encodeVector(vector),
-				Name:        cfg.NamedVector,
-			}
-			objects[i].Vectors = vectors
 		}
 		if cfg.Filter {
 			nonRefProperties, err := structpb.NewStruct(map[string]interface{}{
@@ -369,6 +370,17 @@ func createSchema(cfg *Config, client *weaviate.Client) {
 	vectorIndexConfig["filterStrategy"] = cfg.FilterStrategy
 
 	if cfg.NamedVector != "" {
+		if cfg.MultiVectorDimensions > 0 {
+			vectorIndexConfig["multivector"] = map[string]interface{}{
+				"enabled": true,
+				"muvera": map[string]interface{}{
+					"enabled":      cfg.MuveraEnabled,
+					"ksim":         cfg.MuveraKSim,
+					"dprojections": cfg.MuveraDProjections,
+					"repetition":   cfg.MuveraRepetition,
+				},
+			}
+		}
 		vectorConfig := make(map[string]models.VectorConfig)
 		vectorConfig[cfg.NamedVector] = models.VectorConfig{
 			Vectorizer:        map[string]interface{}{"none": nil},
@@ -611,15 +623,13 @@ func enableCompression(cfg *Config, client *weaviate.Client, dimensions uint, co
 	var segments uint
 	var vectorIndexConfig map[string]interface{}
 
-	if cfg.MultiVectorDimensions > 0 {
+	if cfg.NamedVector != "" {
+		vectorIndexConfig = classConfig.VectorConfig[cfg.NamedVector].VectorIndexConfig.(map[string]interface{})
+		classConfig.Vectorizer = ""
+	} else if cfg.MultiVectorDimensions > 0 {
 		vectorIndexConfig = classConfig.VectorConfig["multivector"].VectorIndexConfig.(map[string]interface{})
 	} else {
-		if cfg.NamedVector == "" {
-			vectorIndexConfig = classConfig.VectorIndexConfig.(map[string]interface{})
-		} else {
-			vectorIndexConfig = classConfig.VectorConfig[cfg.NamedVector].VectorIndexConfig.(map[string]interface{})
-			classConfig.Vectorizer = ""
-		}
+		vectorIndexConfig = classConfig.VectorIndexConfig.(map[string]interface{})
 	}
 
 	switch compressionType {
@@ -662,18 +672,16 @@ func enableCompression(cfg *Config, client *weaviate.Client, dimensions uint, co
 		vectorIndexConfig["rq"] = rqConfig
 	}
 
-	if cfg.MultiVectorDimensions > 0 {
+	if cfg.NamedVector != "" {
+		vectorConfig := classConfig.VectorConfig[cfg.NamedVector]
+		vectorConfig.VectorIndexConfig = vectorIndexConfig
+		classConfig.VectorConfig[cfg.NamedVector] = vectorConfig
+	} else if cfg.MultiVectorDimensions > 0 {
 		vectorConfig := classConfig.VectorConfig["multivector"]
 		vectorConfig.VectorIndexConfig = vectorIndexConfig
 		classConfig.VectorConfig["multivector"] = vectorConfig
 	} else {
-		if cfg.NamedVector == "" {
-			classConfig.VectorIndexConfig = vectorIndexConfig
-		} else {
-			vectorConfig := classConfig.VectorConfig[cfg.NamedVector]
-			vectorConfig.VectorIndexConfig = vectorIndexConfig
-			classConfig.VectorConfig[cfg.NamedVector] = vectorConfig
-		}
+		classConfig.VectorIndexConfig = vectorIndexConfig
 	}
 
 	err = client.Schema().ClassUpdater().WithClass(classConfig).Do(context.Background())

--- a/benchmarker/cmd/random_vectors.go
+++ b/benchmarker/cmd/random_vectors.go
@@ -137,9 +137,14 @@ func encodeVector(fs []float32) []byte {
 
 func nearVectorQueryGrpc(cfg *Config, vec []float32, tenant string, filter int) []byte {
 
-	var searchRequest *weaviategrpc.SearchRequest
-	if cfg.MultiVectorDimensions > 0 {
+	metadata := &weaviategrpc.MetadataRequest{
+		Certainty: false,
+		Distance:  false,
+		Uuid:      true,
+	}
 
+	var nearVector *weaviategrpc.NearVector
+	if cfg.MultiVectorDimensions > 0 {
 		rows := len(vec) / cfg.MultiVectorDimensions
 		doc := make([][]float32, rows)
 		for i := 0; i < rows; i++ {
@@ -147,46 +152,24 @@ func nearVectorQueryGrpc(cfg *Config, vec []float32, tenant string, filter int) 
 			end := start + cfg.MultiVectorDimensions
 			doc[i] = vec[start:end]
 		}
-		multiVec := []*weaviategrpc.Vectors{{
-			Name:        "multivector",
-			VectorBytes: byteops.Fp32SliceOfSlicesToBytes(doc),
-			Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
-		}}
-
-		searchRequest = &weaviategrpc.SearchRequest{
-			Collection: cfg.ClassName,
-			Limit:      uint32(cfg.Limit),
-			NearVector: &weaviategrpc.NearVector{
-				Vectors: multiVec,
-			},
-			Metadata: &weaviategrpc.MetadataRequest{
-				Certainty: false,
-				Distance:  false,
-				Uuid:      true,
-			},
+		name := "multivector"
+		if cfg.NamedVector != "" {
+			name = cfg.NamedVector
 		}
-
-	} else {
-		searchRequest = &weaviategrpc.SearchRequest{
-			Collection: cfg.ClassName,
-			Limit:      uint32(cfg.Limit),
-			NearVector: &weaviategrpc.NearVector{
-				VectorBytes: encodeVector(vec),
-			},
-			Metadata: &weaviategrpc.MetadataRequest{
-				Certainty: false,
-				Distance:  false,
-				Uuid:      true,
-			},
+		nearVector = &weaviategrpc.NearVector{
+			Vectors: []*weaviategrpc.Vectors{{
+				Name:        name,
+				VectorBytes: byteops.Fp32SliceOfSlicesToBytes(doc),
+				Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
+			}},
 		}
-	}
-
-	if tenant != "" {
-		searchRequest.Tenant = tenant
-	}
-
-	if cfg.NamedVector != "" {
-		searchRequest.NearVector = &weaviategrpc.NearVector{
+		if cfg.NamedVector != "" {
+			nearVector.Targets = &weaviategrpc.Targets{
+				TargetVectors: []string{cfg.NamedVector},
+			}
+		}
+	} else if cfg.NamedVector != "" {
+		nearVector = &weaviategrpc.NearVector{
 			Targets: &weaviategrpc.Targets{
 				TargetVectors: []string{cfg.NamedVector},
 			},
@@ -194,6 +177,21 @@ func nearVectorQueryGrpc(cfg *Config, vec []float32, tenant string, filter int) 
 				cfg.NamedVector: encodeVector(vec),
 			},
 		}
+	} else {
+		nearVector = &weaviategrpc.NearVector{
+			VectorBytes: encodeVector(vec),
+		}
+	}
+
+	searchRequest := &weaviategrpc.SearchRequest{
+		Collection: cfg.ClassName,
+		Limit:      uint32(cfg.Limit),
+		NearVector: nearVector,
+		Metadata:   metadata,
+	}
+
+	if tenant != "" {
+		searchRequest.Tenant = tenant
 	}
 
 	if filter >= 0 {


### PR DESCRIPTION
## Summary

Running the benchmarker with both `--namedVector` and `-m` (multivector/Colbert) failed at import time:

```
go run main.go ann-benchmark -v lotte-recreation-reduced-vl-10000.hdf5 \
  -m 128 --indexType hnsw -d cosine --namedVector vector1
...
INFO[0000] Error for index 0: inconsistent vector lengths: 2432 != 2560
INFO[0000] Error for index 1: inconsistent vector lengths: 1664 != 2560
INFO[0000] Error for index 5: inconsistent vector lengths: 1920 != 2560
```

## Root cause

The `cfg.NamedVector != ""` branches in both the ingestion and query paths unconditionally **overwrote** any multivector payload with a single flat `encodeVector(vec)`. For a Colbert dataset with variable token counts (19/13/15/16/20 × 128), each document encoded to a different length and Weaviate rejected every doc whose length differed from the first object in the batch.

The schema-creation branch had the matching gap: when `NamedVector != ""`, the `multivector` / `muvera` block was never added, so Weaviate created a plain single-vector HNSW index regardless of `-m`.

## Changes

| File | Function | Fix |
|------|----------|-----|
| `cmd/ann_benchmark.go` | `writeChunk` | Emit `MULTI_FP32` under `cfg.NamedVector` when both flags set, instead of clobbering |
| `cmd/ann_benchmark.go` | `createSchema` | Inject the `multivector` / `muvera` block into the named vector index config when `-m > 0` |
| `cmd/random_vectors.go` | `nearVectorQueryGrpc` | Query path sends `MULTI_FP32` with `Targets.TargetVectors=[cfg.NamedVector]` when both are set |
| `cmd/ann_benchmark.go` | `enableCompression` | Check `NamedVector` before `MultiVectorDimensions` so compression updates land on the right `VectorConfig` key |

Single-vector + namedVector and multivector-only paths are unchanged.

## Test plan

- [x] `CGO_ENABLED=1 go build ./...`
- [x] `CGO_ENABLED=1 go test ./cmd/...`
- [ ] Repro that originally failed: `go run main.go ann-benchmark -v lotte-recreation-reduced-vl-10000.hdf5 -m 128 --indexType hnsw -d cosine --namedVector vector1` — ingest completes, queries return non-zero recall
- [ ] Regression: `ann-benchmark` with only `-m` (no `--namedVector`) still works
- [ ] Regression: `ann-benchmark` with only `--namedVector` (no `-m`) still works