### PR TITLE
feat(benchmarker): add bm25-benchmark command with tombstone testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,56 @@ For more details on additional configuration options see the help options.
 ```sh
 docker compose run benchmarker /app/benchmarker ann-benchmark -h
 ```
+
+## BM25 benchmark
+
+The `bm25-benchmark` command measures **BM25 keyword-search** performance (latency
+percentiles, QPS, throughput under concurrency) on a [BEIR](https://github.com/beir-cellar/beir)-format
+text corpus. Unlike ANN, BM25 top-k is computed exactly, so this is a pure
+performance test — no recall/ground-truth is used.
+
+### Get a dataset
+
+BEIR datasets ship as a zip containing `corpus.jsonl` and `queries.jsonl`
+(`qrels/` is ignored — this is a performance test, not a relevance evaluation).
+
+```sh
+# small (smoke): nfcorpus (~3.6K docs), scifact (~5K); large (scale): msmarco (~8.8M)
+curl -L -o nfcorpus.zip https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/nfcorpus.zip
+unzip nfcorpus.zip
+```
+
+### Run
+
+```sh
+go run . bm25-benchmark \
+    --corpus nfcorpus/corpus.jsonl \
+    --queriesFile nfcorpus/queries.jsonl \
+    -c Bm25Bench -l 10 -p 8 --bm25Operator or
+```
+
+Results are written to `./results/<runID>.json` (one row per phase), in the same
+shape as `ann-benchmark` so they plug into the existing reporting. See all options
+with `go run . bm25-benchmark -h`.
+
+### Tombstone scenario
+
+BM25 latency can be affected by **inverted-index tombstones** — deleted docIDs that
+still occupy posting slots (from updates/deletes) and must be skipped at query time
+until compaction reclaims them. This scenario measures that effect: it runs a
+0-tombstone baseline, then deletes/re-inserts a fraction of documents and
+re-measures, so you can quantify latency/QPS as tombstone density grows.
+
+```sh
+go run . bm25-benchmark \
+    --corpus nfcorpus/corpus.jsonl --queriesFile nfcorpus/queries.jsonl \
+    -c Bm25Bench -l 10 -p 8 \
+    --tombstonePercentage 0.5 --tombstoneMode update --tombstoneIterations 3 \
+    --labels "weaviateVersion=<commit>,scenario=tombstone"
+```
+
+- `--tombstoneMode update` deletes then reinserts the same documents (one tombstone
+  per doc per iteration, matching an update-heavy workload); `delete` only deletes.
+- `--tombstoneConcurrent` churns tombstones in the background *during* the query run.
+
+

--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -11,6 +11,7 @@ Usage:
 
 Available Commands:
   ann-benchmark  Benchmark ANN Benchmark style datasets
+  bm25-benchmark Benchmark BM25 keyword search on a BEIR-format text corpus
   help           Help about any command
   random-vectors Benchmark random vector queries
   raw            Benchmark raw GraphQL queries
@@ -76,6 +77,88 @@ Flags:
   -v, --vectors string               Path to the hdf5 file containing the vectors
 
 
+```
+
+## BM25 benchmark
+
+The `bm25-benchmark` command imports a [BEIR](https://github.com/beir-cellar/beir)-format text corpus (`corpus.jsonl` + `queries.jsonl`) into a vectorless collection and benchmarks BM25 keyword-search latency/QPS. Unlike ANN, BM25 top-k is exact, so this is a pure performance test (no recall/ground-truth). It can also generate inverted-index tombstones (via deletes/updates) to measure BM25 performance under tombstone load. Results are written to `./results/<runID>.json`, one row per phase, in the same shape as `ann-benchmark`.
+
+Running `benchmarker bm25-benchmark -h` results in the following output:
+
+```
+Import a BEIR-format text corpus (corpus.jsonl) into a vectorless Weaviate
+collection and benchmark BM25 keyword-search latency/QPS using queries.jsonl.
+
+Optionally generates inverted-index tombstones (via deletes/updates) to measure
+BM25 keyword-search performance under tombstone load.
+
+Usage:
+  benchmarker bm25-benchmark [flags]
+
+Flags:
+  -a, --api string                     API to use (only grpc is supported) (default "grpc")
+  -b, --batchSize int                  Batch size for import (default 1000)
+      --bm25Operator string            BM25 search operator: or, and, or empty for server default
+      --bm25b float                    BM25 b parameter (default 0.75)
+      --bm25k1 float                   BM25 k1 parameter (default 1.2)
+  -c, --className string               Class name for the benchmark collection (default "Bm25Bench")
+      --corpus string                  Path to the BEIR corpus.jsonl file (required unless --query)
+      --existingSchema                 Leave the schema as-is (do not recreate the class)
+      --filter                         Combine BM25 with an equality filter on a category bucket
+      --filterCount int                Number of category buckets (filter selectivity = 1/filterCount) (default 10)
+  -f, --format string                  Output format, one of [text, json] (default "text")
+  -u, --grpcOrigin string              The gRPC origin that Weaviate is running at (default "localhost:50051")
+  -h, --help                           help for bm25-benchmark
+      --httpOrigin string              The HTTP origin for Weaviate (default "localhost:8080")
+      --httpScheme string              The HTTP scheme (http or https) (default "http")
+      --labels string                  Labels of format key1=value1,key2=value2 merged into each result row
+  -l, --limit int                      Query limit (top_k) (default 10)
+      --measureBaseline                Run a 0-tombstone baseline before the tombstone phase (default true)
+      --memoryMonitoringEnabled        Enable continuous memory monitoring
+      --memoryMonitoringFile string    Memory monitoring output file
+      --memoryMonitoringInterval int   Memory monitoring interval in seconds (default 5)
+      --metricsEndpoint string         Weaviate metrics endpoint (default "http://localhost:2112/metrics")
+      --minimumOrTokensMatch int       minimumOrTokensMatch for the OR operator (0 = unset)
+      --numTenants int                 Number of tenants; each gets a full corpus copy (0 = single-tenant)
+  -o, --output string                  Optional output file for the results JSON
+  -p, --parallel int                   Number of parallel query threads (default: number of CPUs)
+      --queries int                    Number of query executions per phase (0 = one pass over the query set)
+      --queriesFile string             Path to the BEIR queries.jsonl file (required)
+      --query                          Do not import; query an existing collection
+      --queryDelaySeconds int          How long to wait after import before querying (default 30)
+      --queryDuration int              Query for the specified duration in seconds instead of a fixed count
+      --queryProperties string         Comma-separated properties to run BM25 against (default "text")
+      --replicationFactor int          Replication factor (default 1)
+      --searchType string              Search type (bm25; hybrid reserved for a future version) (default "bm25")
+      --shards int                     Number of shards (default 1)
+      --skipQuery                      Only import data, skip the query phase
+      --tokenization string            Tokenization for the text properties (word, lowercase, whitespace, field, trigram) (default "word")
+      --tombstoneConcurrent            Churn tombstones in the background during the query run
+      --tombstoneIterations int        Number of tombstone-generation iterations (re-measured each time) (default 1)
+      --tombstoneMode string           How to create tombstones: update (delete+reinsert) or delete (default "update")
+      --tombstonePercentage float      Fraction of docs (0..1) to tombstone per iteration (0 disables)
+```
+
+Download a BEIR dataset (e.g. the small `nfcorpus`) and run a pure BM25 benchmark:
+
+```
+curl -L -o nfcorpus.zip https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/nfcorpus.zip
+unzip nfcorpus.zip
+
+go run . bm25-benchmark \
+  --corpus nfcorpus/corpus.jsonl \
+  --queriesFile nfcorpus/queries.jsonl \
+  -c Bm25Bench -l 10 -p 8 --bm25Operator or
+```
+
+To measure BM25 latency under inverted-index tombstone load, run a 0-tombstone baseline followed by one or more delete/reinsert iterations (record the Weaviate version via `--labels`, since tombstone handling varies across versions):
+
+```
+go run . bm25-benchmark \
+  --corpus nfcorpus/corpus.jsonl --queriesFile nfcorpus/queries.jsonl \
+  -c Bm25Bench -l 10 -p 8 \
+  --tombstonePercentage 0.5 --tombstoneMode update --tombstoneIterations 2 \
+  --labels "weaviateVersion=<commit>"
 ```
 
 ## Memory Monitoring Feature 🆕

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -43,6 +43,8 @@ const (
 // Batch of vectors and offset for writing to Weaviate
 type Batch struct {
 	Vectors [][]float32
+	Text    []string // BM25/text import; parallel to Vectors (nil for pure-ANN batches)
+	Titles  []string // optional per-object title, parallel to Text
 	Offset  int
 	Filters []int
 }
@@ -98,9 +100,14 @@ func intFromUUID(uuidStr string) int {
 
 // Writes a single batch of vectors to Weaviate using gRPC
 func writeChunk(chunk *Batch, client *weaviategrpc.WeaviateClient, cfg *Config) {
-	objects := make([]*weaviategrpc.BatchObject, len(chunk.Vectors))
+	n := len(chunk.Vectors)
+	if n == 0 {
+		// Text-only (BM25) batches carry no vectors.
+		n = len(chunk.Text)
+	}
+	objects := make([]*weaviategrpc.BatchObject, n)
 
-	for i, vector := range chunk.Vectors {
+	for i := 0; i < n; i++ {
 		objects[i] = &weaviategrpc.BatchObject{
 			Uuid:       uuidFromInt(i + chunk.Offset + cfg.Offset),
 			Collection: cfg.ClassName,
@@ -108,42 +115,59 @@ func writeChunk(chunk *Batch, client *weaviategrpc.WeaviateClient, cfg *Config) 
 		if cfg.Tenant != "" {
 			objects[i].Tenant = cfg.Tenant
 		}
-		if cfg.MultiVectorDimensions > 0 {
-			if len(vector)%cfg.MultiVectorDimensions != 0 {
-				log.Fatalf("Vector length %d is not a multiple of dimensions %d",
-					len(vector), cfg.MultiVectorDimensions)
-			}
-			rows := len(vector) / cfg.MultiVectorDimensions
+		if i < len(chunk.Vectors) {
+			vector := chunk.Vectors[i]
+			if cfg.MultiVectorDimensions > 0 {
+				if len(vector)%cfg.MultiVectorDimensions != 0 {
+					log.Fatalf("Vector length %d is not a multiple of dimensions %d",
+						len(vector), cfg.MultiVectorDimensions)
+				}
+				rows := len(vector) / cfg.MultiVectorDimensions
 
-			multiVec := make([][]float32, rows)
-			for i := 0; i < rows; i++ {
-				start := i * cfg.MultiVectorDimensions
-				end := start + cfg.MultiVectorDimensions
-				multiVec[i] = vector[start:end]
+				multiVec := make([][]float32, rows)
+				for j := 0; j < rows; j++ {
+					start := j * cfg.MultiVectorDimensions
+					end := start + cfg.MultiVectorDimensions
+					multiVec[j] = vector[start:end]
+				}
+				name := "multivector"
+				if cfg.NamedVector != "" {
+					name = cfg.NamedVector
+				}
+				objects[i].Vectors = []*weaviategrpc.Vectors{{
+					Name:        name,
+					VectorBytes: byteops.Fp32SliceOfSlicesToBytes(multiVec),
+					Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
+				}}
+			} else if cfg.NamedVector != "" {
+				objects[i].Vectors = []*weaviategrpc.Vectors{{
+					Name:        cfg.NamedVector,
+					VectorBytes: encodeVector(vector),
+				}}
+			} else {
+				objects[i].VectorBytes = encodeVector(vector)
 			}
-			name := "multivector"
-			if cfg.NamedVector != "" {
-				name = cfg.NamedVector
+		}
+
+		// Object properties. For pure-ANN batches this only sets "category" when
+		// filtering is enabled (unchanged behavior). BM25/text batches add the
+		// searchable "text"/"title" properties plus a numeric "docId" used for
+		// range-based batch deletes during tombstone generation.
+		props := map[string]interface{}{}
+		if i < len(chunk.Text) {
+			props["text"] = chunk.Text[i]
+			props["docId"] = float64(i + chunk.Offset + cfg.Offset)
+			if i < len(chunk.Titles) {
+				props["title"] = chunk.Titles[i]
 			}
-			objects[i].Vectors = []*weaviategrpc.Vectors{{
-				Name:        name,
-				VectorBytes: byteops.Fp32SliceOfSlicesToBytes(multiVec),
-				Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
-			}}
-		} else if cfg.NamedVector != "" {
-			objects[i].Vectors = []*weaviategrpc.Vectors{{
-				Name:        cfg.NamedVector,
-				VectorBytes: encodeVector(vector),
-			}}
-		} else {
-			objects[i].VectorBytes = encodeVector(vector)
 		}
 		if cfg.Filter {
-			nonRefProperties, err := structpb.NewStruct(map[string]interface{}{
-				"category": strconv.Itoa(chunk.Filters[i]),
-			})
+			props["category"] = strconv.Itoa(chunk.Filters[i])
+		}
+		if len(props) > 0 {
+			nonRefProperties, err := structpb.NewStruct(props)
 			if err != nil {
-				log.Fatalf("Error creating filtered struct: %v", err)
+				log.Fatalf("Error creating properties struct: %v", err)
 			}
 			objects[i].Properties = &weaviategrpc.BatchObject_Properties{
 				NonRefProperties: nonRefProperties,

--- a/benchmarker/cmd/beir_dataset.go
+++ b/benchmarker/cmd/beir_dataset.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// beirMaxLineBytes bounds a single JSONL line. BEIR corpus documents (e.g. full
+// Wikipedia passages) routinely exceed bufio.Scanner's default 64KB limit, so we
+// raise it to avoid "token too long" errors mid-stream.
+const beirMaxLineBytes = 16 * 1024 * 1024
+
+// beirCorpusDoc mirrors one line of a BEIR corpus.jsonl file.
+type beirCorpusDoc struct {
+	ID    string `json:"_id"`
+	Title string `json:"title"`
+	Text  string `json:"text"`
+}
+
+// beirQuery mirrors one line of a BEIR queries.jsonl file.
+type beirQuery struct {
+	ID   string `json:"_id"`
+	Text string `json:"text"`
+}
+
+// BeirDataset streams a BEIR-format text corpus (corpus.jsonl) into text batches
+// for import and loads the query set (queries.jsonl) for BM25 benchmarking.
+//
+// It implements the Dataset interface so it can reuse the existing loadTrainData
+// import pipeline unchanged. BM25 benchmarking is vectorless, so the
+// vector-specific interface methods are no-ops. Qrels are intentionally ignored:
+// this is a performance benchmark, not a relevance evaluation.
+type BeirDataset struct {
+	corpusPath  string
+	queriesPath string
+	useFilter   bool
+	filterCount int
+	corpusCount int // cached line count; -1 until computed
+}
+
+// NewBeirDataset creates a loader for a BEIR dataset. When useFilter is set each
+// document is assigned a "category" bucket (index % filterCount) so BM25 queries
+// can be combined with a property filter of controllable selectivity.
+func NewBeirDataset(corpusPath, queriesPath string, useFilter bool, filterCount int) *BeirDataset {
+	if filterCount <= 0 {
+		filterCount = 1
+	}
+	return &BeirDataset{
+		corpusPath:  corpusPath,
+		queriesPath: queriesPath,
+		useFilter:   useFilter,
+		filterCount: filterCount,
+		corpusCount: -1,
+	}
+}
+
+// StreamTrainData reads corpus.jsonl and emits Batches of text objects. It honors
+// startOffset (skip the first N documents) and maxRecords (stop after N emitted
+// documents, 0 = all) so the same corpus can be re-streamed to reinsert a
+// document range during tombstone generation. Each batch's Offset is the absolute
+// corpus index of its first document, keeping generated UUIDs / docIds stable
+// across passes.
+func (d *BeirDataset) StreamTrainData(chunks chan<- Batch, batchSize, startOffset, maxRecords int) {
+	f, err := os.Open(d.corpusPath)
+	if err != nil {
+		log.Fatalf("Error opening corpus file %s: %v", d.corpusPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+
+	batchText := make([]string, 0, batchSize)
+	batchTitles := make([]string, 0, batchSize)
+	var batchFilters []int
+	batchStart := startOffset
+
+	flush := func() {
+		if len(batchText) == 0 {
+			return
+		}
+		chunks <- Batch{
+			Text:    batchText,
+			Titles:  batchTitles,
+			Filters: batchFilters,
+			Offset:  batchStart,
+		}
+		batchText = make([]string, 0, batchSize)
+		batchTitles = make([]string, 0, batchSize)
+		batchFilters = nil
+	}
+
+	idx := 0     // absolute position in the corpus file
+	emitted := 0 // documents emitted so far (after startOffset)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if idx < startOffset {
+			idx++
+			continue
+		}
+		if maxRecords > 0 && emitted >= maxRecords {
+			break
+		}
+
+		var doc beirCorpusDoc
+		if err := json.Unmarshal(line, &doc); err != nil {
+			log.Fatalf("Error parsing corpus line %d: %v", idx, err)
+		}
+		batchText = append(batchText, doc.Text)
+		batchTitles = append(batchTitles, doc.Title)
+		if d.useFilter {
+			batchFilters = append(batchFilters, idx%d.filterCount)
+		}
+		idx++
+		emitted++
+
+		if len(batchText) >= batchSize {
+			flush()
+			batchStart = idx
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
+	}
+	flush()
+}
+
+// LoadQueries reads queries.jsonl and returns the query strings (the "text"
+// field of each line). Query IDs and qrels are ignored for performance testing.
+func (d *BeirDataset) LoadQueries() []string {
+	f, err := os.Open(d.queriesPath)
+	if err != nil {
+		log.Fatalf("Error opening queries file %s: %v", d.queriesPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+
+	var queries []string
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var q beirQuery
+		if err := json.Unmarshal(line, &q); err != nil {
+			log.Fatalf("Error parsing query line: %v", err)
+		}
+		if q.Text != "" {
+			queries = append(queries, q.Text)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading queries file %s: %v", d.queriesPath, err)
+	}
+	return queries
+}
+
+// NumTrainVectors returns the number of documents in the corpus (non-empty
+// lines). The result is cached; the first call scans the file once. Used to
+// convert a tombstone percentage into an absolute document count.
+func (d *BeirDataset) NumTrainVectors() int {
+	if d.corpusCount >= 0 {
+		return d.corpusCount
+	}
+	f, err := os.Open(d.corpusPath)
+	if err != nil {
+		log.Fatalf("Error opening corpus file %s: %v", d.corpusPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+	count := 0
+	for scanner.Scan() {
+		if len(scanner.Bytes()) > 0 {
+			count++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
+	}
+	d.corpusCount = count
+	return count
+}
+
+// Dataset interface methods that are not meaningful for a vectorless BM25 corpus.
+func (d *BeirDataset) TestVectors() [][]float32 { return nil }
+func (d *BeirDataset) Neighbors() [][]int       { return nil }
+func (d *BeirDataset) TrainFilters() []int      { return nil }
+func (d *BeirDataset) TestFilters() []int       { return nil }
+func (d *BeirDataset) Dimension() int           { return 0 }
+func (d *BeirDataset) Close()                   {}

--- a/benchmarker/cmd/beir_dataset_test.go
+++ b/benchmarker/cmd/beir_dataset_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBeirFixture(t *testing.T, dir, name string, lines []string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", name, err)
+	}
+	return path
+}
+
+func drainBatches(ds *BeirDataset, batchSize, startOffset, maxRecords int) (offsets []int, texts, titles []string, filters []int) {
+	chunks := make(chan Batch, 16)
+	go func() {
+		ds.StreamTrainData(chunks, batchSize, startOffset, maxRecords)
+		close(chunks)
+	}()
+	for b := range chunks {
+		offsets = append(offsets, b.Offset)
+		texts = append(texts, b.Text...)
+		titles = append(titles, b.Titles...)
+		filters = append(filters, b.Filters...)
+	}
+	return offsets, texts, titles, filters
+}
+
+func TestBeirDatasetStreamAndQueries(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeBeirFixture(t, dir, "corpus.jsonl", []string{
+		`{"_id":"d0","title":"T0","text":"alpha beta"}`,
+		`{"_id":"d1","title":"T1","text":"gamma"}`,
+		`{"_id":"d2","title":"T2","text":"delta epsilon"}`,
+		`{"_id":"d3","title":"T3","text":"zeta"}`,
+		`{"_id":"d4","title":"T4","text":"eta"}`,
+	})
+	queries := writeBeirFixture(t, dir, "queries.jsonl", []string{
+		`{"_id":"q0","text":"alpha"}`,
+		`{"_id":"q1","text":"delta"}`,
+	})
+
+	ds := NewBeirDataset(corpus, queries, true, 2)
+
+	if got := ds.NumTrainVectors(); got != 5 {
+		t.Errorf("NumTrainVectors = %d, want 5", got)
+	}
+
+	offsets, texts, titles, filters := drainBatches(ds, 2, 0, 0)
+
+	wantTexts := []string{"alpha beta", "gamma", "delta epsilon", "zeta", "eta"}
+	if len(texts) != len(wantTexts) {
+		t.Fatalf("got %d texts, want %d", len(texts), len(wantTexts))
+	}
+	for i, w := range wantTexts {
+		if texts[i] != w {
+			t.Errorf("text[%d] = %q, want %q", i, texts[i], w)
+		}
+	}
+	wantTitles := []string{"T0", "T1", "T2", "T3", "T4"}
+	for i, w := range wantTitles {
+		if titles[i] != w {
+			t.Errorf("title[%d] = %q, want %q", i, titles[i], w)
+		}
+	}
+
+	// Filter buckets = absolute index % filterCount(2).
+	wantFilters := []int{0, 1, 0, 1, 0}
+	if len(filters) != len(wantFilters) {
+		t.Fatalf("got %d filters, want %d", len(filters), len(wantFilters))
+	}
+	for i, w := range wantFilters {
+		if filters[i] != w {
+			t.Errorf("filter[%d] = %d, want %d", i, filters[i], w)
+		}
+	}
+
+	// Batch offsets are the absolute corpus index of each batch's first doc.
+	wantOffsets := []int{0, 2, 4}
+	if len(offsets) != len(wantOffsets) {
+		t.Fatalf("got %d batches, want %d", len(offsets), len(wantOffsets))
+	}
+	for i, w := range wantOffsets {
+		if offsets[i] != w {
+			t.Errorf("offset[%d] = %d, want %d", i, offsets[i], w)
+		}
+	}
+
+	// Range re-stream (used by tombstone "update" reinsert): only the first 2 docs.
+	rangeOffsets, rangeTexts, _, _ := drainBatches(ds, 2, 0, 2)
+	if len(rangeTexts) != 2 {
+		t.Errorf("range restream got %d docs, want 2", len(rangeTexts))
+	}
+	if len(rangeOffsets) != 1 || rangeOffsets[0] != 0 {
+		t.Errorf("range restream offsets = %v, want [0]", rangeOffsets)
+	}
+
+	qs := ds.LoadQueries()
+	if len(qs) != 2 || qs[0] != "alpha" || qs[1] != "delta" {
+		t.Errorf("LoadQueries = %v, want [alpha delta]", qs)
+	}
+}

--- a/benchmarker/cmd/bm25_benchmark.go
+++ b/benchmarker/cmd/bm25_benchmark.go
@@ -1,0 +1,506 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/filters"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+var bm25BenchmarkCommand = &cobra.Command{
+	Use:   "bm25-benchmark",
+	Short: "Benchmark BM25 keyword search on a BEIR-format text corpus",
+	Long: `Import a BEIR-format text corpus (corpus.jsonl) into a vectorless Weaviate
+collection and benchmark BM25 keyword-search latency/QPS using queries.jsonl.
+
+Optionally generates inverted-index tombstones (via deletes/updates) to measure
+BM25 keyword-search performance under tombstone load.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := globalConfig
+		cfg.Mode = "bm25-benchmark"
+
+		if err := cfg.Validate(); err != nil {
+			fatal(err)
+		}
+		cfg.parseLabels()
+
+		memoryMonitor := NewMemoryMonitor(&cfg)
+		memoryMonitor.Start()
+		defer memoryMonitor.Stop()
+
+		ds := NewBeirDataset(cfg.CorpusFile, cfg.QueriesFile, cfg.Filter, cfg.FilterCount)
+		defer ds.Close()
+
+		client := createClient(&cfg)
+
+		var importTime time.Duration
+		if !cfg.QueryOnly {
+			if !cfg.ExistingSchema {
+				createBM25Schema(&cfg, client)
+			}
+			log.WithFields(log.Fields{
+				"class": cfg.ClassName, "corpus": cfg.CorpusFile, "filter": cfg.Filter,
+			}).Info("Starting BM25 import")
+			importTime = loadBM25Data(ds, &cfg, client)
+
+			sleepDuration := time.Duration(cfg.QueryDelaySeconds) * time.Second
+			log.Printf("Waiting for %s to allow flush/compaction to settle", sleepDuration)
+			time.Sleep(sleepDuration)
+		}
+
+		if cfg.SkipQuery {
+			return
+		}
+
+		queries := ds.LoadQueries()
+		if len(queries) == 0 {
+			fatal(fmt.Errorf("no queries loaded from %s", cfg.QueriesFile))
+		}
+		log.WithFields(log.Fields{"queries": len(queries)}).Info("Loaded BM25 queries")
+
+		runBM25Queries(&cfg, client, ds, queries, importTime)
+	},
+}
+
+// createBM25Schema (re)creates the benchmark collection: a vectorless class with a
+// searchable "text"/"title" property (BM25 inverted index), a numeric "docId"
+// (enables range-based batch deletes for tombstone generation), and an optional
+// filterable "category" property. NB: InvertedIndexConfig.CleanupIntervalSeconds
+// is deliberately not set — it is a no-op for inverted buckets in Weaviate.
+func createBM25Schema(cfg *Config, client *weaviate.Client) {
+	if err := client.Schema().ClassDeleter().WithClassName(cfg.ClassName).Do(context.Background()); err != nil {
+		log.Warnf("Error deleting class %s (may not exist yet): %v", cfg.ClassName, err)
+	}
+
+	tokenization := cfg.Tokenization
+	if tokenization == "" {
+		tokenization = "word"
+	}
+
+	properties := []*models.Property{
+		{
+			Name:            "text",
+			DataType:        []string{"text"},
+			Tokenization:    tokenization,
+			IndexSearchable: boolPtr(true),
+			IndexFilterable: boolPtr(false),
+		},
+		{
+			Name:            "title",
+			DataType:        []string{"text"},
+			Tokenization:    tokenization,
+			IndexSearchable: boolPtr(true),
+			IndexFilterable: boolPtr(false),
+		},
+		{
+			Name:            "docId",
+			DataType:        []string{"int"},
+			IndexFilterable: boolPtr(true),
+			IndexSearchable: boolPtr(false),
+		},
+	}
+	if cfg.Filter {
+		properties = append(properties, &models.Property{
+			Name:            "category",
+			DataType:        []string{"text"},
+			IndexFilterable: boolPtr(true),
+			IndexSearchable: boolPtr(false),
+		})
+	}
+
+	invertedIndexConfig := &models.InvertedIndexConfig{}
+	if cfg.BM25K1 > 0 || cfg.BM25B > 0 {
+		invertedIndexConfig.Bm25 = &models.BM25Config{
+			K1: float32(cfg.BM25K1),
+			B:  float32(cfg.BM25B),
+		}
+	}
+
+	classObj := &models.Class{
+		Class:               cfg.ClassName,
+		Description:         fmt.Sprintf("Created by the Weaviate BM25 Benchmarker at %s", time.Now().String()),
+		Vectorizer:          "none",
+		Properties:          properties,
+		InvertedIndexConfig: invertedIndexConfig,
+	}
+	if cfg.NumTenants > 0 {
+		classObj.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+	}
+	if cfg.Shards > 1 {
+		classObj.ShardingConfig = map[string]interface{}{"desiredCount": cfg.Shards}
+	}
+	if cfg.ReplicationFactor > 1 || cfg.AsyncReplicationEnabled {
+		classObj.ReplicationConfig = &models.ReplicationConfig{
+			Factor:       int64(cfg.ReplicationFactor),
+			AsyncEnabled: cfg.AsyncReplicationEnabled,
+		}
+	}
+
+	if err := client.Schema().ClassCreator().WithClass(classObj).Do(context.Background()); err != nil {
+		log.Fatalf("Error creating class %s: %v", cfg.ClassName, err)
+	}
+	log.Printf("Created BM25 class %s", cfg.ClassName)
+}
+
+// loadBM25Data imports the corpus using the shared 8-worker import pipeline. With
+// multi-tenancy it imports a full copy of the corpus into each tenant (mirroring
+// the ANN multi-tenant path). Tenant-scoped work uses local Config copies so the
+// shared cfg is never mutated.
+func loadBM25Data(ds *BeirDataset, cfg *Config, client *weaviate.Client) time.Duration {
+	start := time.Now()
+	if cfg.NumTenants > 0 {
+		for i := 0; i < cfg.NumTenants; i++ {
+			tenantCfg := *cfg
+			tenantCfg.Tenant = fmt.Sprintf("%d", i)
+			addTenantIfNeeded(&tenantCfg, client)
+			loadTrainData(ds, &tenantCfg, 0, 0, 0)
+		}
+	} else {
+		loadTrainData(ds, cfg, 0, 0, 0)
+	}
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{"duration": elapsed, "tenants": cfg.NumTenants}).Printf("BM25 import complete")
+	return elapsed
+}
+
+// runBM25Queries runs the phased measurement (baseline, then tombstone phases if
+// requested) and writes one labeled result row per phase to ./results/{runID}.json.
+func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queries []string, importTime time.Duration) {
+	runID := fmt.Sprintf("%d", time.Now().Unix())
+	var rows []map[string]interface{}
+
+	measure := func(phase string, iteration int, tombstoneRatio float64) {
+		var result Results
+		if cfg.QueryDuration > 0 {
+			result = benchmarkBM25Duration(*cfg, queries)
+		} else {
+			result = benchmarkBM25(*cfg, queries)
+		}
+		log.WithFields(log.Fields{
+			"phase": phase, "iteration": iteration, "tombstoneRatio": tombstoneRatio,
+			"mean": result.Mean, "qps": result.QueriesPerSecond,
+			"parallel": cfg.Parallel, "limit": cfg.Limit, "failed": result.Failed,
+		}).Infof("BM25 %s result", phase)
+		if _, err := result.WriteTextTo(os.Stdout); err != nil {
+			log.Warnf("Error writing results to stdout: %v", err)
+		}
+		rows = append(rows, bm25ResultRow(cfg, result, importTime, runID, phase, iteration, tombstoneRatio))
+	}
+
+	// Baseline (0 tombstones). Always run when there is no tombstone phase, so at
+	// least one measurement is produced.
+	if cfg.MeasureBaseline || cfg.TombstonePercentage <= 0 {
+		measure("baseline", 0, 0)
+	}
+
+	if cfg.TombstonePercentage > 0 {
+		total := ds.NumTrainVectors()
+		k := int(math.Floor(cfg.TombstonePercentage * float64(total)))
+		if k < 1 {
+			k = 1
+		}
+		iterations := cfg.TombstoneIterations
+		if iterations < 1 {
+			iterations = 1
+		}
+
+		if cfg.TombstoneConcurrent {
+			// Sustain churn in the background while a single query window runs.
+			stop := make(chan struct{})
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						generateTombstones(cfg, client, ds, k)
+					}
+				}
+			}()
+			measure("concurrent", 0, cfg.TombstonePercentage)
+			close(stop)
+			<-done
+		} else {
+			for it := 1; it <= iterations; it++ {
+				generateTombstones(cfg, client, ds, k)
+				measure("tombstoned", it, cfg.TombstonePercentage*float64(it))
+			}
+		}
+	}
+
+	writeBM25Results(cfg, runID, rows)
+}
+
+// benchmarkBM25 runs one pass (or cfg.Queries executions) of BM25 queries through
+// the shared worker-pool harness. Neighbors are left empty so recall/NDCG are
+// skipped (this is a pure performance test).
+func benchmarkBM25(cfg Config, queries []string) Results {
+	if cfg.Queries == 0 {
+		cfg.Queries = len(queries)
+	}
+	i := 0
+	return benchmark(cfg, func(className string) QueryWithNeighbors {
+		query := queries[i%len(queries)]
+		i++
+		tenant := cfg.Tenant
+		if cfg.NumTenants > 0 {
+			tenant = fmt.Sprintf("%d", rand.Intn(cfg.NumTenants))
+		}
+		filter := -1
+		if cfg.Filter && cfg.FilterCount > 0 {
+			filter = rand.Intn(cfg.FilterCount)
+		}
+		return QueryWithNeighbors{
+			Query: bm25QueryGrpc(&cfg, query, tenant, filter),
+		}
+	})
+}
+
+// benchmarkBM25Duration repeats benchmarkBM25 for cfg.QueryDuration seconds and
+// returns the median across runs (mirrors benchmarkANNDuration).
+func benchmarkBM25Duration(cfg Config, queries []string) Results {
+	var samples sampledResults
+	startTime := time.Now()
+	var results Results
+	iterations := 0
+	for time.Since(startTime) < time.Duration(cfg.QueryDuration)*time.Second {
+		results = benchmarkBM25(cfg, queries)
+		samples.Min = append(samples.Min, results.Min)
+		samples.Max = append(samples.Max, results.Max)
+		samples.Mean = append(samples.Mean, results.Mean)
+		samples.Took = append(samples.Took, results.Took)
+		samples.QueriesPerSecond = append(samples.QueriesPerSecond, results.QueriesPerSecond)
+		samples.Results = append(samples.Results, results)
+		iterations++
+	}
+
+	var medianResult Results
+	medianResult.Min = time.Duration(median(samples.Min))
+	medianResult.Max = time.Duration(median(samples.Max))
+	medianResult.Mean = time.Duration(median(samples.Mean))
+	medianResult.Took = time.Duration(median(samples.Took))
+	medianResult.QueriesPerSecond = median(samples.QueriesPerSecond)
+	medianResult.Percentiles = results.Percentiles
+	medianResult.PercentilesLabels = results.PercentilesLabels
+	medianResult.Total = results.Total
+	medianResult.Successful = results.Successful
+	medianResult.Failed = results.Failed
+	medianResult.Parallelization = cfg.Parallel
+
+	log.WithFields(log.Fields{"iterations": iterations}).Infof("Queried for %d seconds", cfg.QueryDuration)
+	return medianResult
+}
+
+// generateTombstones creates inverted-index tombstones for the first k documents
+// (docId < k). Under multi-tenancy each tenant has its own inverted index, so it
+// churns every tenant. It never mutates the shared cfg (it passes per-tenant
+// Config copies), which keeps it safe to run concurrently with the query phase.
+func generateTombstones(cfg *Config, client *weaviate.Client, ds *BeirDataset, k int) {
+	if cfg.NumTenants > 0 {
+		for i := 0; i < cfg.NumTenants; i++ {
+			tombstoneOnce(*cfg, client, ds, k, fmt.Sprintf("%d", i))
+		}
+		return
+	}
+	tombstoneOnce(*cfg, client, ds, k, cfg.Tenant)
+}
+
+// tombstoneOnce deletes docId < k in a single tenant (empty tenant = single-tenant
+// mode). In "update" mode it reinserts those same documents (identical UUIDs +
+// docIds) so the corpus size holds and each old docID becomes a fresh tombstone —
+// matching an update-heavy workload. cfg is taken by value so the tenant
+// assignment stays local.
+func tombstoneOnce(cfg Config, client *weaviate.Client, ds *BeirDataset, k int, tenant string) {
+	cfg.Tenant = tenant
+	deleted := batchDeleteDocIDRange(&cfg, client, k)
+	log.WithFields(log.Fields{
+		"deleted": deleted, "mode": cfg.TombstoneMode, "range": k, "tenant": tenant,
+	}).Printf("Generated tombstones")
+
+	if cfg.TombstoneMode == "delete" {
+		return
+	}
+	// Default ("update"): reinsert the same document range.
+	loadTrainData(ds, &cfg, 0, uint(k), 0)
+}
+
+// batchDeleteDocIDRange deletes all objects with docId < end, looping because the
+// server deletes at most QUERY_MAXIMUM_RESULTS (~10k) objects per call. Returns
+// the total number of objects deleted.
+func batchDeleteDocIDRange(cfg *Config, client *weaviate.Client, end int) int64 {
+	where := filters.Where().
+		WithPath([]string{"docId"}).
+		WithOperator(filters.LessThan).
+		WithValueInt(int64(end))
+
+	var total int64
+	for {
+		deleter := client.Batch().ObjectsBatchDeleter().
+			WithClassName(cfg.ClassName).
+			WithWhere(where).
+			WithOutput("minimal")
+		if cfg.Tenant != "" {
+			deleter = deleter.WithTenant(cfg.Tenant)
+		}
+		resp, err := deleter.Do(context.Background())
+		if err != nil {
+			log.Fatalf("Error batch-deleting objects for tombstones: %v", err)
+		}
+		if resp.Results == nil || resp.Results.Successful == 0 {
+			break
+		}
+		total += resp.Results.Successful
+	}
+	return total
+}
+
+// bm25ResultRow builds one JSON result row, reusing the ANN-compatible
+// ResultsJSONBenchmark shape and adding BM25/tombstone-specific fields plus any
+// user --labels, so runs remain ingestible by weaviate-performance-tests.
+func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID, phase string, iteration int, tombstoneRatio float64) map[string]interface{} {
+	p99 := 0.0
+	if len(result.Percentiles) > 0 {
+		p99 = result.Percentiles[len(result.Percentiles)-1].Seconds()
+	}
+	benchResult := ResultsJSONBenchmark{
+		Api:              cfg.API,
+		Mean:             result.Mean.Seconds(),
+		P99Latency:       p99,
+		QueriesPerSecond: result.QueriesPerSecond,
+		Shards:           cfg.Shards,
+		Parallelization:  cfg.Parallel,
+		Limit:            cfg.Limit,
+		ImportTime:       importTime.Seconds(),
+		RunID:            runID,
+		IterationRunID:   fmt.Sprintf("%d", iteration),
+		Dataset:          filepath.Base(cfg.CorpusFile),
+		Timestamp:        time.Now().Format(time.RFC3339),
+	}
+
+	jsonData, err := json.Marshal(benchResult)
+	if err != nil {
+		log.Fatalf("Error converting result to json: %v", err)
+	}
+	var row map[string]interface{}
+	if err := json.Unmarshal(jsonData, &row); err != nil {
+		log.Fatalf("Error converting json to map: %v", err)
+	}
+
+	row["phase"] = phase
+	row["tombstoneRatio"] = tombstoneRatio
+	row["tombstoneMode"] = cfg.TombstoneMode
+	row["bm25Operator"] = cfg.BM25Operator
+	row["queryProperties"] = cfg.QueryProperties
+	row["bm25k1"] = cfg.BM25K1
+	row["bm25b"] = cfg.BM25B
+	if cfg.Filter {
+		row["filterCount"] = cfg.FilterCount
+	}
+	for key, value := range cfg.LabelMap {
+		row[key] = value
+	}
+	return row
+}
+
+func writeBM25Results(cfg *Config, runID string, rows []map[string]interface{}) {
+	if len(rows) == 0 {
+		return
+	}
+	data, err := json.MarshalIndent(rows, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling benchmark results: %v", err)
+	}
+
+	if err := os.MkdirAll("./results", 0o755); err != nil {
+		log.Fatalf("Error creating results directory: %v", err)
+	}
+	path := fmt.Sprintf("./results/%s.json", runID)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		log.Fatalf("Error writing benchmark results to file: %v", err)
+	}
+	log.Printf("Wrote BM25 results to %s", path)
+
+	if cfg.OutputFile != "" {
+		if err := os.WriteFile(cfg.OutputFile, data, 0o644); err != nil {
+			log.Warnf("Error writing to output file %s: %v", cfg.OutputFile, err)
+		}
+	}
+}
+
+func initBM25Benchmark() {
+	rootCmd.AddCommand(bm25BenchmarkCommand)
+
+	numCPU := runtime.NumCPU()
+	f := bm25BenchmarkCommand.PersistentFlags()
+
+	// Dataset & schema
+	f.StringVar(&globalConfig.CorpusFile, "corpus", "", "Path to the BEIR corpus.jsonl file (required unless --query)")
+	f.StringVar(&globalConfig.QueriesFile, "queriesFile", "", "Path to the BEIR queries.jsonl file (required)")
+	f.StringVarP(&globalConfig.ClassName, "className", "c", "Bm25Bench", "Class name for the benchmark collection")
+	f.StringVar(&globalConfig.Tokenization, "tokenization", "word", "Tokenization for the text properties (word, lowercase, whitespace, field, trigram)")
+	f.Float64Var(&globalConfig.BM25K1, "bm25k1", 1.2, "BM25 k1 parameter")
+	f.Float64Var(&globalConfig.BM25B, "bm25b", 0.75, "BM25 b parameter")
+
+	// Query behavior
+	f.StringVar(&globalConfig.SearchType, "searchType", "bm25", "Search type (bm25; hybrid reserved for a future version)")
+	f.StringVar(&globalConfig.QueryProperties, "queryProperties", "text", "Comma-separated properties to run BM25 against")
+	f.StringVar(&globalConfig.BM25Operator, "bm25Operator", "", "BM25 search operator: or, and, or empty for server default")
+	f.IntVar(&globalConfig.MinOrTokens, "minimumOrTokensMatch", 0, "minimumOrTokensMatch for the OR operator (0 = unset)")
+	f.IntVar(&globalConfig.Queries, "queries", 0, "Number of query executions per phase (0 = one pass over the query set)")
+	f.IntVar(&globalConfig.QueryDuration, "queryDuration", 0, "Query for the specified duration in seconds instead of a fixed count")
+	f.IntVarP(&globalConfig.Limit, "limit", "l", 10, "Query limit (top_k)")
+	f.IntVarP(&globalConfig.Parallel, "parallel", "p", numCPU, "Number of parallel query threads")
+
+	// Filtering
+	f.BoolVar(&globalConfig.Filter, "filter", false, "Combine BM25 with an equality filter on a category bucket")
+	f.IntVar(&globalConfig.FilterCount, "filterCount", 10, "Number of category buckets (filter selectivity = 1/filterCount)")
+
+	// Tombstone generation
+	f.Float64Var(&globalConfig.TombstonePercentage, "tombstonePercentage", 0.0, "Fraction of docs (0..1) to tombstone per iteration (0 disables)")
+	f.StringVar(&globalConfig.TombstoneMode, "tombstoneMode", "update", "How to create tombstones: update (delete+reinsert) or delete")
+	f.IntVar(&globalConfig.TombstoneIterations, "tombstoneIterations", 1, "Number of tombstone-generation iterations (re-measured each time)")
+	f.BoolVar(&globalConfig.TombstoneConcurrent, "tombstoneConcurrent", false, "Churn tombstones in the background during the query run")
+	f.BoolVar(&globalConfig.MeasureBaseline, "measureBaseline", true, "Run a 0-tombstone baseline before the tombstone phase")
+
+	// Import & topology
+	f.IntVarP(&globalConfig.BatchSize, "batchSize", "b", 1000, "Batch size for import")
+	f.IntVar(&globalConfig.NumTenants, "numTenants", 0, "Number of tenants; each gets a full corpus copy (0 = single-tenant)")
+	f.IntVar(&globalConfig.Shards, "shards", 1, "Number of shards")
+	f.IntVar(&globalConfig.ReplicationFactor, "replicationFactor", 1, "Replication factor")
+
+	// Connection & output
+	f.StringVarP(&globalConfig.Origin, "grpcOrigin", "u", "localhost:50051", "The gRPC origin that Weaviate is running at")
+	f.StringVar(&globalConfig.HttpOrigin, "httpOrigin", "localhost:8080", "The HTTP origin for Weaviate")
+	f.StringVar(&globalConfig.HttpScheme, "httpScheme", "http", "The HTTP scheme (http or https)")
+	f.StringVarP(&globalConfig.API, "api", "a", "grpc", "API to use (only grpc is supported)")
+	f.StringVar(&globalConfig.Labels, "labels", "", "Labels of format key1=value1,key2=value2 merged into each result row")
+	f.StringVarP(&globalConfig.OutputFormat, "format", "f", "text", "Output format, one of [text, json]")
+	f.StringVarP(&globalConfig.OutputFile, "output", "o", "", "Optional output file for the results JSON")
+
+	// Lifecycle / skip options
+	f.BoolVar(&globalConfig.QueryOnly, "query", false, "Do not import; query an existing collection")
+	f.BoolVar(&globalConfig.SkipQuery, "skipQuery", false, "Only import data, skip the query phase")
+	f.BoolVar(&globalConfig.ExistingSchema, "existingSchema", false, "Leave the schema as-is (do not recreate the class)")
+	f.IntVar(&globalConfig.QueryDelaySeconds, "queryDelaySeconds", 30, "How long to wait after import before querying")
+
+	// Memory monitoring
+	f.StringVar(&globalConfig.MetricsEndpoint, "metricsEndpoint", "http://localhost:2112/metrics", "Weaviate metrics endpoint")
+	f.BoolVar(&globalConfig.MemoryMonitoringEnabled, "memoryMonitoringEnabled", false, "Enable continuous memory monitoring")
+	f.IntVar(&globalConfig.MemoryMonitoringInterval, "memoryMonitoringInterval", 5, "Memory monitoring interval in seconds")
+	f.StringVar(&globalConfig.MemoryMonitoringFile, "memoryMonitoringFile", "", "Memory monitoring output file")
+}

--- a/benchmarker/cmd/bm25_query.go
+++ b/benchmarker/cmd/bm25_query.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// queryPropertiesList parses the comma-separated --queryProperties flag into the
+// set of properties a BM25 query scores against. Defaults to ["text"].
+func (cfg *Config) queryPropertiesList() []string {
+	parts := strings.Split(cfg.QueryProperties, ",")
+	props := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			props = append(props, t)
+		}
+	}
+	if len(props) == 0 {
+		return []string{"text"}
+	}
+	return props
+}
+
+// bm25QueryGrpc builds a marshalled gRPC SearchRequest for a BM25 keyword query.
+// It mirrors nearVectorQueryGrpc:
+//   - Metadata requests the object UUID (required — processQueueGrpc decodes each
+//     result's UUID back into an int and uuid.Parse("") would panic).
+//   - When BM25Operator is "and"/"or", the corresponding SearchOperatorOptions is
+//     set (with MinimumOrTokensMatch for the OR case); otherwise it is left nil so
+//     the server default applies.
+//   - filter >= 0 adds an equality filter on the "category" property, enabling
+//     filtered BM25 runs of controllable selectivity.
+func bm25QueryGrpc(cfg *Config, query, tenant string, filter int) []byte {
+	metadata := &weaviategrpc.MetadataRequest{
+		Uuid: true,
+	}
+
+	bm25 := &weaviategrpc.BM25{
+		Query:      query,
+		Properties: cfg.queryPropertiesList(),
+	}
+
+	switch cfg.BM25Operator {
+	case "and":
+		bm25.SearchOperator = &weaviategrpc.SearchOperatorOptions{
+			Operator: weaviategrpc.SearchOperatorOptions_OPERATOR_AND,
+		}
+	case "or":
+		op := &weaviategrpc.SearchOperatorOptions{
+			Operator: weaviategrpc.SearchOperatorOptions_OPERATOR_OR,
+		}
+		if cfg.MinOrTokens > 0 {
+			minTokens := int32(cfg.MinOrTokens)
+			op.MinimumOrTokensMatch = &minTokens
+		}
+		bm25.SearchOperator = op
+	}
+
+	searchRequest := &weaviategrpc.SearchRequest{
+		Collection: cfg.ClassName,
+		Limit:      uint32(cfg.Limit),
+		Bm25Search: bm25,
+		Metadata:   metadata,
+	}
+
+	if tenant != "" {
+		searchRequest.Tenant = tenant
+	}
+
+	if filter >= 0 {
+		searchRequest.Filters = &weaviategrpc.Filters{
+			TestValue: &weaviategrpc.Filters_ValueText{
+				ValueText: strconv.Itoa(filter),
+			},
+			On:       []string{"category"},
+			Operator: weaviategrpc.Filters_OPERATOR_EQUAL,
+		}
+	}
+
+	data, err := proto.Marshal(searchRequest)
+	if err != nil {
+		fmt.Printf("grpc marshal err: %v\n", err)
+	}
+
+	return data
+}
+
+// Hybrid (BM25 + vector) seam for a future version. The gRPC message already
+// exists as weaviategrpc.Hybrid{Query, Properties, Vector/Vectors, Alpha,
+// FusionType, NearVector, Bm25SearchOperator}. To add hybrid benchmarking:
+//   1. Implement hybridQueryGrpc setting SearchRequest.HybridSearch (analogous to
+//      the Bm25Search wiring above).
+//   2. Add a "hybrid" branch to the query selector in benchmarkBM25.
+//   3. Give each imported document a vector (Batch.Vectors) and a vector index in
+//      createBM25Schema — for perf-only, a deterministic randomVector suffices.
+// The BEIR loader, worker-pool harness, and results output are all unchanged.

--- a/benchmarker/cmd/bm25_query_test.go
+++ b/benchmarker/cmd/bm25_query_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"testing"
+
+	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func unmarshalSearchRequest(t *testing.T, data []byte) *weaviategrpc.SearchRequest {
+	t.Helper()
+	var sr weaviategrpc.SearchRequest
+	if err := proto.Unmarshal(data, &sr); err != nil {
+		t.Fatalf("unmarshal SearchRequest: %v", err)
+	}
+	return &sr
+}
+
+func TestBM25QueryGrpc_OrOperatorAndProperties(t *testing.T) {
+	cfg := &Config{
+		ClassName:       "Bm25Bench",
+		Limit:           10,
+		QueryProperties: "text,title",
+		BM25Operator:    "or",
+		MinOrTokens:     2,
+	}
+
+	sr := unmarshalSearchRequest(t, bm25QueryGrpc(cfg, "alpha beta", "", -1))
+
+	if sr.Collection != "Bm25Bench" {
+		t.Errorf("collection = %q, want Bm25Bench", sr.Collection)
+	}
+	if sr.Limit != 10 {
+		t.Errorf("limit = %d, want 10", sr.Limit)
+	}
+	if sr.Metadata == nil || !sr.Metadata.Uuid {
+		t.Error("metadata.uuid must be true (else result-id decode panics)")
+	}
+	if sr.Bm25Search == nil {
+		t.Fatal("bm25Search is nil")
+	}
+	if sr.Bm25Search.Query != "alpha beta" {
+		t.Errorf("query = %q, want 'alpha beta'", sr.Bm25Search.Query)
+	}
+	if got := sr.Bm25Search.Properties; len(got) != 2 || got[0] != "text" || got[1] != "title" {
+		t.Errorf("properties = %v, want [text title]", got)
+	}
+	op := sr.Bm25Search.SearchOperator
+	if op == nil || op.Operator != weaviategrpc.SearchOperatorOptions_OPERATOR_OR {
+		t.Fatalf("search operator = %v, want OR", op)
+	}
+	if op.MinimumOrTokensMatch == nil || *op.MinimumOrTokensMatch != 2 {
+		t.Errorf("minimumOrTokensMatch = %v, want 2", op.MinimumOrTokensMatch)
+	}
+	if sr.Filters != nil {
+		t.Errorf("filters must be nil when filter < 0, got %v", sr.Filters)
+	}
+}
+
+func TestBM25QueryGrpc_FilterAndTenant(t *testing.T) {
+	cfg := &Config{ClassName: "C", Limit: 5, QueryProperties: "text"}
+	sr := unmarshalSearchRequest(t, bm25QueryGrpc(cfg, "gamma", "tenantA", 3))
+
+	if sr.Tenant != "tenantA" {
+		t.Errorf("tenant = %q, want tenantA", sr.Tenant)
+	}
+	if sr.Filters == nil {
+		t.Fatal("filters nil, want category==3")
+	}
+	if sr.Filters.Operator != weaviategrpc.Filters_OPERATOR_EQUAL {
+		t.Errorf("filter operator = %v, want EQUAL", sr.Filters.Operator)
+	}
+	if len(sr.Filters.On) != 1 || sr.Filters.On[0] != "category" {
+		t.Errorf("filter on = %v, want [category]", sr.Filters.On)
+	}
+	vt, ok := sr.Filters.TestValue.(*weaviategrpc.Filters_ValueText)
+	if !ok || vt.ValueText != "3" {
+		t.Errorf("filter value = %v, want ValueText 3", sr.Filters.TestValue)
+	}
+}
+
+func TestBM25QueryGrpc_Defaults(t *testing.T) {
+	// Empty QueryProperties defaults to ["text"]; AND operator; no min-tokens.
+	cfg := &Config{ClassName: "C", Limit: 5, BM25Operator: "and"}
+	sr := unmarshalSearchRequest(t, bm25QueryGrpc(cfg, "q", "", -1))
+	if got := sr.Bm25Search.Properties; len(got) != 1 || got[0] != "text" {
+		t.Errorf("default properties = %v, want [text]", got)
+	}
+	if sr.Bm25Search.SearchOperator == nil ||
+		sr.Bm25Search.SearchOperator.Operator != weaviategrpc.SearchOperatorOptions_OPERATOR_AND {
+		t.Error("expected AND operator")
+	}
+
+	// No operator specified → SearchOperator left nil (server default applies).
+	cfgNoOp := &Config{ClassName: "C", Limit: 5}
+	srNoOp := unmarshalSearchRequest(t, bm25QueryGrpc(cfgNoOp, "q", "", -1))
+	if srNoOp.Bm25Search.SearchOperator != nil {
+		t.Errorf("expected nil SearchOperator when BM25Operator unset, got %v", srNoOp.Bm25Search.SearchOperator)
+	}
+}

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -82,6 +82,24 @@ type Config struct {
 	MaxPostingSizeKB         int
 	Replicas                 int
 	RngFactor                float64
+
+	// BM25 benchmark
+	CorpusFile      string
+	SearchType      string
+	QueryProperties string
+	BM25Operator    string
+	MinOrTokens     int
+	BM25K1          float64
+	BM25B           float64
+	Tokenization    string
+	FilterCount     int
+
+	// BM25 tombstone generation (slow-path reproduction)
+	TombstonePercentage float64
+	TombstoneMode       string
+	TombstoneIterations int
+	TombstoneConcurrent bool
+	MeasureBaseline     bool
 }
 
 func (c *Config) Validate() error {
@@ -99,6 +117,8 @@ func (c *Config) Validate() error {
 		return c.validateDataset()
 	case "ann-benchmark":
 		return c.validateANN()
+	case "bm25-benchmark":
+		return c.validateBM25()
 	default:
 		return errors.Errorf("unrecognized mode %q", c.Mode)
 	}
@@ -186,6 +206,48 @@ func (c Config) validateANN() error {
 
 	if c.DistanceMetric == "" {
 		return errors.Errorf("distance metric must be set")
+	}
+
+	return nil
+}
+
+func (c Config) validateBM25() error {
+	if c.API != "grpc" {
+		return errors.Errorf("only grpc is supported for bm25-benchmark")
+	}
+
+	if !c.QueryOnly && c.CorpusFile == "" {
+		return errors.Errorf("a corpus file (--corpus, BEIR corpus.jsonl) must be provided unless --query is set")
+	}
+
+	if c.QueriesFile == "" {
+		return errors.Errorf("a queries file (--queriesFile, BEIR queries.jsonl) must be provided")
+	}
+
+	switch c.TombstoneMode {
+	case "", "update", "delete":
+	default:
+		return errors.Errorf("unsupported tombstoneMode %q, must be one of [update, delete]", c.TombstoneMode)
+	}
+
+	if c.TombstonePercentage < 0 || c.TombstonePercentage > 1 {
+		return errors.Errorf("tombstonePercentage must be between 0 and 1")
+	}
+
+	if c.TombstonePercentage > 0 && c.CorpusFile == "" {
+		return errors.Errorf("a corpus file (--corpus) is required to generate tombstones")
+	}
+
+	if c.TombstoneConcurrent && c.QueryDuration <= 0 {
+		return errors.Errorf("--tombstoneConcurrent requires --queryDuration > 0 so queries overlap the background churn")
+	}
+
+	if c.TombstoneConcurrent && c.TombstoneMode == "delete" {
+		return errors.Errorf("--tombstoneConcurrent requires --tombstoneMode update (delete does not sustain churn)")
+	}
+
+	if c.Parallel < 1 {
+		return errors.Errorf("parallel must be at least 1")
 	}
 
 	return nil

--- a/benchmarker/cmd/root.go
+++ b/benchmarker/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 	initDataset()
 	initRaw()
 	initAnnBenchmark()
+	initBM25Benchmark()
 	initColbert()
 }
 


### PR DESCRIPTION
## Motivation

We can benchmark ANN query performance today, but we have no equivalent harness for **BM25 keyword search** — and in particular no way to reproduce and quantify the latency degradation that inverted-index **tombstones** cause. When documents are updated or deleted, their old docIDs remain in the posting lists as tombstones and must be skipped at query time until compaction reclaims them. Under update-heavy workloads this can meaningfully hurt BM25 latency/QPS, and we needed a repeatable way to measure it against real corpora.

This PR adds a `bm25-benchmark` command that imports a [BEIR](https://github.com/beir-cellar/beir)-format text corpus into a vectorless collection and measures BM25 latency/QPS through the existing worker-pool harness, with an optional tombstone-generation mode to measure performance under inverted-index churn.

## Approach

The guiding decision was to **reuse the existing import and measurement machinery rather than fork it**:

- `BeirDataset` implements the existing `Dataset` interface, so the same 8-worker `loadTrainData` pipeline imports the corpus unchanged. Vector-specific interface methods are no-ops; qrels are ignored because this is a performance test, not a relevance eval. Recall/NDCG are skipped since BM25 top-k is exact.
- BM25 queries reuse the shared `benchmark(...)` worker pool and the ANN-compatible JSON result shape, so runs plug straight into existing reporting.
- Tombstone density is measured **phased**: a 0-tombstone baseline, then delete/reinsert a fraction of docs and re-measure per iteration (or sustain churn in the background for a concurrent-churn variant).
- Multi-tenancy is supported: each tenant gets a full corpus copy, and tombstone churn is tenant-aware (per-tenant `Config` copies, no shared mutation).

The one invasive change is in `ann_benchmark.go`: `Batch`/`writeChunk` were generalized to carry optional text properties so the BM25 path could share them. This was done as a **behavior-preserving refactor** of the existing ANN write path (the loop now iterates over `max(len(vectors), len(text))` and only touches vectors when present).

Hybrid (BM25 + vector) was intentionally left out but the seam is documented in `bm25_query.go`.

## Key areas for review

- `benchmarker/cmd/ann_benchmark.go` `writeChunk` — **the riskiest change**, the only edit to the shared ANN import path. Verify the pure-ANN branches (named vector, multivector, filter-only) are unchanged; note the inner multivector loop variable was renamed `i`→`j` to avoid shadowing the outer object index.
- `benchmarker/cmd/bm25_query.go` `bm25QueryGrpc` — `Metadata.Uuid` **must** stay `true`; `processQueueGrpc` decodes each result UUID back into an int and `uuid.Parse("")` would panic. There's a test guarding this.
- `benchmarker/cmd/bm25_benchmark.go` `generateTombstones` / `tombstoneOnce` — concurrency safety: these run alongside the query phase in `--tombstoneConcurrent` mode. `cfg` is taken by value so tenant assignment stays local and the shared config is never mutated.
- `benchmarker/cmd/bm25_benchmark.go` `batchDeleteDocIDRange` — the delete loop (server caps deletes at ~10k/call); verify termination on `Successful == 0`.
- `benchmarker/cmd/beir_dataset.go` `StreamTrainData` — `startOffset`/`maxRecords` + absolute `Offset` are what make reinsert produce **stable UUIDs/docIds**, which makes "update" a true update rather than a duplicate insert.

## Risks and mitigations

- **Regression in the existing `ann-benchmark` import path**: the `writeChunk` rewrite is behavior-preserving; validated by inspection and the existing suite (the ANN unit tests stay green). Worth a careful read of that function.
- **Race between background churn and queries** (`--tombstoneConcurrent`): mitigated by passing per-tenant `Config` copies (by value) into the churn goroutine — no shared mutable state is touched during the query window; the goroutine is stopped and joined via `stop`/`done` channels before results are written. Validation also requires `--queryDuration > 0` and `--tombstoneMode update` for this mode.
- **UUID/docId drift across reinsert passes** would turn "update" into duplicate inserts: prevented by deriving UUIDs deterministically from the absolute corpus offset, so reinserting docId range `[0,k)` reuses identical UUIDs and genuinely overwrites.
- **Oversized corpus lines** (full passages exceed bufio's 64KB default): scanner buffer raised to 16MB.

## Testing

Unit tests (no Weaviate required), passing (`go test ./cmd/...`, incl. `-race`):
- `bm25_query_test.go` — the gRPC query builder: OR operator with `minimumOrTokensMatch` + multi-property scoring, AND operator, category filter + tenant wiring, defaults, and the `Metadata.Uuid == true` invariant.
- `beir_dataset_test.go` — the loader end-to-end on a fixture: streaming into batches, absolute batch offsets, filter-bucket assignment (`idx % filterCount`), the range re-stream used by tombstone "update" reinsert, and query parsing.

Manually validated end-to-end against a live Weaviate on NFCorpus (single-tenant and 3-tenant): import → baseline → tombstone iterations → results JSON, with latency/QPS degrading as tombstone density grows, and update-mode preserving corpus size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
