### PR TITLE
feat(benchmarker): add bm25-benchmark command with tombstone testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ docker compose run benchmarker /app/benchmarker ann-benchmark -h
 
 The `bm25-benchmark` command measures **BM25 keyword-search** performance (latency
 percentiles, QPS, throughput under concurrency) on a [BEIR](https://github.com/beir-cellar/beir)-format
-text corpus. Unlike ANN, BM25 top-k is computed exactly, so this is a pure
-performance test — no recall/ground-truth is used.
+text corpus. Unlike ANN, BM25 top-k is computed exactly, so by default this is a
+pure performance test — add `--measureQuality` to also compute NDCG/Recall against
+the dataset's qrels as a regression gate (see below).
 
 ### Get a dataset
 
 BEIR datasets ship as a zip containing `corpus.jsonl` and `queries.jsonl`
-(`qrels/` is ignored — this is a performance test, not a relevance evaluation).
+(`qrels/` is only read with `--measureQuality`; otherwise ignored).
 
 ```sh
 # small (smoke): nfcorpus (~3.6K docs), scifact (~5K); large (scale): msmarco (~8.8M)
@@ -117,9 +118,10 @@ go run . bm25-benchmark \
 
 - The qrels file auto-detects at `<corpusdir>/qrels/test.tsv` (then `dev.tsv`); override with `--qrels`.
 - Cutoffs are decoupled from `--limit`: tune with `--ndcgCutoff` / `--recallCutoff`.
-- In quality mode the tombstone churn targets the **judged** docs and a
-  **retrievability probe** (`tombstoneRetrievability`) checks reinserted docs stay
-  findable — the direct tombstone-correctness signal.
+- In quality mode the update-churn targets the **judged** docs (the rows'
+  `tombstoneRatio` then reflects the judged fraction actually churned, not
+  `--tombstonePercentage`) and a **retrievability probe** (`tombstoneRetrievability`)
+  checks reinserted docs stay findable — the direct tombstone-correctness signal.
 - Rows carry a `benchmarkType: bm25-qrels` label. **When comparing runs downstream,
   use negative thresholds** (e.g. `ndcg: -0.02`) so *decreases* are flagged, and never
   mix BM25 and ANN result files (their `recall`/`ndcg` are on different scales).

--- a/README.md
+++ b/README.md
@@ -99,4 +99,32 @@ go run . bm25-benchmark \
   per doc per iteration, matching an update-heavy workload); `delete` only deletes.
 - `--tombstoneConcurrent` churns tombstones in the background *during* the query run.
 
+### Quality measurement (regression gate)
+
+`--measureQuality` computes **NDCG@10** and **Recall@100 vs the BEIR qrels** for each
+phase (filling the `recall`/`ndcg` fields), so a change that degrades what BM25
+returns — a tombstone/WAND regression or a new Weaviate version — shows up as a drop
+in those metrics. The reference (qrels) ships with the dataset, so nothing is stored
+between runs; comparison happens downstream exactly like ANN recall.
+
+```sh
+go run . bm25-benchmark \
+  --corpus benchmark-data/scifact/corpus.jsonl \
+  --queriesFile benchmark-data/scifact/queries.jsonl \
+  --measureQuality --queryProperties text,title \
+  --tombstonePercentage 0.5 --tombstoneMode update
+```
+
+- The qrels file auto-detects at `<corpusdir>/qrels/test.tsv` (then `dev.tsv`); override with `--qrels`.
+- Cutoffs are decoupled from `--limit`: tune with `--ndcgCutoff` / `--recallCutoff`.
+- In quality mode the tombstone churn targets the **judged** docs and a
+  **retrievability probe** (`tombstoneRetrievability`) checks reinserted docs stay
+  findable — the direct tombstone-correctness signal.
+- Rows carry a `benchmarkType: bm25-qrels` label. **When comparing runs downstream,
+  use negative thresholds** (e.g. `ndcg: -0.02`) so *decreases* are flagged, and never
+  mix BM25 and ANN result files (their `recall`/`ndcg` are on different scales).
+- Note: absolute scores sit below published Anserini BEIR numbers (Weaviate's default
+  tokenization does no stemming/stopword removal). Use `--queryProperties text,title`
+  and treat the value as an internally-calibrated band.
+
 

--- a/README.md
+++ b/README.md
@@ -47,3 +47,56 @@ For more details on additional configuration options see the help options.
 ```sh
 docker compose run benchmarker /app/benchmarker ann-benchmark -h
 ```
+
+## BM25 benchmark
+
+The `bm25-benchmark` command measures **BM25 keyword-search** performance (latency
+percentiles, QPS, throughput under concurrency) on a [BEIR](https://github.com/beir-cellar/beir)-format
+text corpus. Unlike ANN, BM25 top-k is computed exactly, so this is a pure
+performance test — no recall/ground-truth is used.
+
+### Get a dataset
+
+BEIR datasets ship as a zip containing `corpus.jsonl` and `queries.jsonl`
+(`qrels/` is ignored — this is a performance test, not a relevance evaluation).
+
+```sh
+# small (smoke): nfcorpus (~3.6K docs), scifact (~5K); large (scale): msmarco (~8.8M)
+curl -L -o nfcorpus.zip https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/nfcorpus.zip
+unzip nfcorpus.zip
+```
+
+### Run
+
+```sh
+go run . bm25-benchmark \
+    --corpus nfcorpus/corpus.jsonl \
+    --queriesFile nfcorpus/queries.jsonl \
+    -c Bm25Bench -l 10 -p 8 --bm25Operator or
+```
+
+Results are written to `./results/<runID>.json` (one row per phase), in the same
+shape as `ann-benchmark` so they plug into the existing reporting. See all options
+with `go run . bm25-benchmark -h`.
+
+### Tombstone scenario
+
+BM25 latency can be affected by **inverted-index tombstones** — deleted docIDs that
+still occupy posting slots (from updates/deletes) and must be skipped at query time
+until compaction reclaims them. This scenario measures that effect: it runs a
+0-tombstone baseline, then deletes/re-inserts a fraction of documents and
+re-measures, so you can quantify latency/QPS as tombstone density grows.
+
+```sh
+go run . bm25-benchmark \
+    --corpus nfcorpus/corpus.jsonl --queriesFile nfcorpus/queries.jsonl \
+    -c Bm25Bench -l 10 -p 8 \
+    --tombstonePercentage 0.5 --tombstoneMode update --tombstoneIterations 3 \
+    --labels "weaviateVersion=<commit>,scenario=tombstone"
+```
+
+- `--tombstoneMode update` deletes then reinserts the same documents (one tombstone
+  per doc per iteration, matching an update-heavy workload); `delete` only deletes.
+- `--tombstoneConcurrent` churns tombstones in the background *during* the query run.
+
+

--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -81,7 +81,7 @@ Flags:
 
 ## BM25 benchmark
 
-The `bm25-benchmark` command imports a [BEIR](https://github.com/beir-cellar/beir)-format text corpus (`corpus.jsonl` + `queries.jsonl`) into a vectorless collection and benchmarks BM25 keyword-search latency/QPS. Unlike ANN, BM25 top-k is exact, so this is a pure performance test (no recall/ground-truth). It can also generate inverted-index tombstones (via deletes/updates) to measure BM25 performance under tombstone load. Results are written to `./results/<runID>.json`, one row per phase, in the same shape as `ann-benchmark`.
+The `bm25-benchmark` command imports a [BEIR](https://github.com/beir-cellar/beir)-format text corpus (`corpus.jsonl` + `queries.jsonl`) into a vectorless collection and benchmarks BM25 keyword-search latency/QPS. By default it is a pure performance test; `--measureQuality` additionally computes NDCG@10 / Recall@100 vs the BEIR qrels as a quality regression gate (see below). It can also generate inverted-index tombstones (via deletes/updates) to measure BM25 performance under tombstone load. Results are written to `./results/<runID>.json`, one row per phase, in the same shape as `ann-benchmark`.
 
 Running `benchmarker bm25-benchmark -h` results in the following output:
 
@@ -114,20 +114,24 @@ Flags:
       --labels string                  Labels of format key1=value1,key2=value2 merged into each result row
   -l, --limit int                      Query limit (top_k) (default 10)
       --measureBaseline                Run a 0-tombstone baseline before the tombstone phase (default true)
+      --measureQuality                 Measure NDCG@k / Recall@k vs BEIR qrels (fills recall/ndcg)
       --memoryMonitoringEnabled        Enable continuous memory monitoring
       --memoryMonitoringFile string    Memory monitoring output file
       --memoryMonitoringInterval int   Memory monitoring interval in seconds (default 5)
       --metricsEndpoint string         Weaviate metrics endpoint (default "http://localhost:2112/metrics")
       --minimumOrTokensMatch int       minimumOrTokensMatch for the OR operator (0 = unset)
+      --ndcgCutoff int                 NDCG cutoff written to the ndcg field (default 10)
       --numTenants int                 Number of tenants; each gets a full corpus copy (0 = single-tenant)
   -o, --output string                  Optional output file for the results JSON
   -p, --parallel int                   Number of parallel query threads (default: number of CPUs)
+      --qrels string                   Path to BEIR qrels TSV; if empty, auto-detect <corpusdir>/qrels/{test,dev}.tsv
       --queries int                    Number of query executions per phase (0 = one pass over the query set)
       --queriesFile string             Path to the BEIR queries.jsonl file (required)
       --query                          Do not import; query an existing collection
       --queryDelaySeconds int          How long to wait after import before querying (default 30)
       --queryDuration int              Query for the specified duration in seconds instead of a fixed count
       --queryProperties string         Comma-separated properties to run BM25 against (default "text")
+      --recallCutoff int               Recall cutoff written to the recall field (default 100)
       --replicationFactor int          Replication factor (default 1)
       --searchType string              Search type (bm25; hybrid reserved for a future version) (default "bm25")
       --shards int                     Number of shards (default 1)
@@ -160,6 +164,29 @@ go run . bm25-benchmark \
   --tombstonePercentage 0.5 --tombstoneMode update --tombstoneIterations 2 \
   --labels "weaviateVersion=<commit>"
 ```
+
+### Quality regression gate (`--measureQuality`)
+
+`--measureQuality` fills the `recall`/`ndcg` fields with **Recall@100** and **NDCG@10 vs
+the BEIR qrels** (the relevance judgments that ship with the dataset), so a change that
+degrades what BM25 returns — a tombstone/WAND regression or a Weaviate upgrade — shows
+up as a metric drop that the downstream comparison can flag, exactly like ANN recall.
+
+```
+go run . bm25-benchmark \
+  --corpus benchmark-data/scifact/corpus.jsonl \
+  --queriesFile benchmark-data/scifact/queries.jsonl \
+  --measureQuality --queryProperties text,title \
+  --tombstonePercentage 0.5 --tombstoneMode update
+```
+
+- Qrels auto-detect at `<corpusdir>/qrels/test.tsv` (then `dev.tsv`); override with `--qrels`.
+- Cutoffs are independent of `--limit` (`--ndcgCutoff` / `--recallCutoff`), so `recall`/`ndcg` mean the same thing across runs.
+- The quality pass is deterministic, single-tenant and unfiltered; latency/QPS still come from the throughput pass.
+- Before measuring, quality mode **waits for the index to settle** (relevant docs searchable, then the metric stops climbing), so import/reindex lag on a multi-node cluster isn't misread as a regression. This adds wall-clock time on a lagging cluster; a genuine regression (docs never recover) still surfaces as a low `tombstoneRetrievability` and a metric drop.
+- In quality mode the tombstone churn targets the **judged** documents, and a **retrievability probe** (`tombstoneRetrievability`) verifies reinserted docs stay findable — the direct tombstone-correctness signal.
+- Rows are labeled `benchmarkType: bm25-qrels`. Downstream, use **negative thresholds** (e.g. `ndcg: -0.02`) to flag *decreases*, and never compare BM25 and ANN result files together (their `recall`/`ndcg` are on different scales).
+- Absolute scores sit below published Anserini BEIR numbers (Weaviate's default tokenization does no stemming/stopword removal); use `--queryProperties text,title` and treat the value as an internally-calibrated band.
 
 ## Memory Monitoring Feature 🆕
 

--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -184,7 +184,7 @@ go run . bm25-benchmark \
 - Cutoffs are independent of `--limit` (`--ndcgCutoff` / `--recallCutoff`), so `recall`/`ndcg` mean the same thing across runs.
 - The quality pass is deterministic, single-tenant and unfiltered; latency/QPS still come from the throughput pass.
 - Before measuring, quality mode **waits for the index to settle** (relevant docs searchable, then the metric stops climbing), so import/reindex lag on a multi-node cluster isn't misread as a regression. This adds wall-clock time on a lagging cluster; a genuine regression (docs never recover) still surfaces as a low `tombstoneRetrievability` and a metric drop.
-- In quality mode the tombstone churn targets the **judged** documents, and a **retrievability probe** (`tombstoneRetrievability`) verifies reinserted docs stay findable — the direct tombstone-correctness signal.
+- In quality mode the update-churn targets the **judged** documents (the rows' `tombstoneRatio` then reflects the judged fraction actually churned, not `--tombstonePercentage`), and a **retrievability probe** (`tombstoneRetrievability`) verifies reinserted docs stay findable — the direct tombstone-correctness signal.
 - Rows are labeled `benchmarkType: bm25-qrels`. Downstream, use **negative thresholds** (e.g. `ndcg: -0.02`) to flag *decreases*, and never compare BM25 and ANN result files together (their `recall`/`ndcg` are on different scales).
 - Absolute scores sit below published Anserini BEIR numbers (Weaviate's default tokenization does no stemming/stopword removal); use `--queryProperties text,title` and treat the value as an internally-calibrated band.
 

--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -11,6 +11,7 @@ Usage:
 
 Available Commands:
   ann-benchmark  Benchmark ANN Benchmark style datasets
+  bm25-benchmark Benchmark BM25 keyword search on a BEIR-format text corpus
   help           Help about any command
   random-vectors Benchmark random vector queries
   raw            Benchmark raw GraphQL queries
@@ -76,6 +77,88 @@ Flags:
   -v, --vectors string               Path to the hdf5 file containing the vectors
 
 
+```
+
+## BM25 benchmark
+
+The `bm25-benchmark` command imports a [BEIR](https://github.com/beir-cellar/beir)-format text corpus (`corpus.jsonl` + `queries.jsonl`) into a vectorless collection and benchmarks BM25 keyword-search latency/QPS. Unlike ANN, BM25 top-k is exact, so this is a pure performance test (no recall/ground-truth). It can also generate inverted-index tombstones (via deletes/updates) to measure BM25 performance under tombstone load. Results are written to `./results/<runID>.json`, one row per phase, in the same shape as `ann-benchmark`.
+
+Running `benchmarker bm25-benchmark -h` results in the following output:
+
+```
+Import a BEIR-format text corpus (corpus.jsonl) into a vectorless Weaviate
+collection and benchmark BM25 keyword-search latency/QPS using queries.jsonl.
+
+Optionally generates inverted-index tombstones (via deletes/updates) to measure
+BM25 keyword-search performance under tombstone load.
+
+Usage:
+  benchmarker bm25-benchmark [flags]
+
+Flags:
+  -a, --api string                     API to use (only grpc is supported) (default "grpc")
+  -b, --batchSize int                  Batch size for import (default 1000)
+      --bm25Operator string            BM25 search operator: or, and, or empty for server default
+      --bm25b float                    BM25 b parameter (default 0.75)
+      --bm25k1 float                   BM25 k1 parameter (default 1.2)
+  -c, --className string               Class name for the benchmark collection (default "Bm25Bench")
+      --corpus string                  Path to the BEIR corpus.jsonl file (required unless --query)
+      --existingSchema                 Leave the schema as-is (do not recreate the class)
+      --filter                         Combine BM25 with an equality filter on a category bucket
+      --filterCount int                Number of category buckets (filter selectivity = 1/filterCount) (default 10)
+  -f, --format string                  Output format, one of [text, json] (default "text")
+  -u, --grpcOrigin string              The gRPC origin that Weaviate is running at (default "localhost:50051")
+  -h, --help                           help for bm25-benchmark
+      --httpOrigin string              The HTTP origin for Weaviate (default "localhost:8080")
+      --httpScheme string              The HTTP scheme (http or https) (default "http")
+      --labels string                  Labels of format key1=value1,key2=value2 merged into each result row
+  -l, --limit int                      Query limit (top_k) (default 10)
+      --measureBaseline                Run a 0-tombstone baseline before the tombstone phase (default true)
+      --memoryMonitoringEnabled        Enable continuous memory monitoring
+      --memoryMonitoringFile string    Memory monitoring output file
+      --memoryMonitoringInterval int   Memory monitoring interval in seconds (default 5)
+      --metricsEndpoint string         Weaviate metrics endpoint (default "http://localhost:2112/metrics")
+      --minimumOrTokensMatch int       minimumOrTokensMatch for the OR operator (0 = unset)
+      --numTenants int                 Number of tenants; each gets a full corpus copy (0 = single-tenant)
+  -o, --output string                  Optional output file for the results JSON
+  -p, --parallel int                   Number of parallel query threads (default: number of CPUs)
+      --queries int                    Number of query executions per phase (0 = one pass over the query set)
+      --queriesFile string             Path to the BEIR queries.jsonl file (required)
+      --query                          Do not import; query an existing collection
+      --queryDelaySeconds int          How long to wait after import before querying (default 30)
+      --queryDuration int              Query for the specified duration in seconds instead of a fixed count
+      --queryProperties string         Comma-separated properties to run BM25 against (default "text")
+      --replicationFactor int          Replication factor (default 1)
+      --searchType string              Search type (bm25; hybrid reserved for a future version) (default "bm25")
+      --shards int                     Number of shards (default 1)
+      --skipQuery                      Only import data, skip the query phase
+      --tokenization string            Tokenization for the text properties (word, lowercase, whitespace, field, trigram) (default "word")
+      --tombstoneConcurrent            Churn tombstones in the background during the query run
+      --tombstoneIterations int        Number of tombstone-generation iterations (re-measured each time) (default 1)
+      --tombstoneMode string           How to create tombstones: update (delete+reinsert) or delete (default "update")
+      --tombstonePercentage float      Fraction of docs (0..1) to tombstone per iteration (0 disables)
+```
+
+Download a BEIR dataset (e.g. the small `nfcorpus`) and run a pure BM25 benchmark:
+
+```
+curl -L -o nfcorpus.zip https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/nfcorpus.zip
+unzip nfcorpus.zip
+
+go run . bm25-benchmark \
+  --corpus nfcorpus/corpus.jsonl \
+  --queriesFile nfcorpus/queries.jsonl \
+  -c Bm25Bench -l 10 -p 8 --bm25Operator or
+```
+
+To measure BM25 latency under inverted-index tombstone load, run a 0-tombstone baseline followed by one or more delete/reinsert iterations (record the Weaviate version via `--labels`, since tombstone handling varies across versions):
+
+```
+go run . bm25-benchmark \
+  --corpus nfcorpus/corpus.jsonl --queriesFile nfcorpus/queries.jsonl \
+  -c Bm25Bench -l 10 -p 8 \
+  --tombstonePercentage 0.5 --tombstoneMode update --tombstoneIterations 2 \
+  --labels "weaviateVersion=<commit>"
 ```
 
 ## Memory Monitoring Feature 🆕

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -512,15 +512,16 @@ func deleteChunk(chunk *Batch, client *weaviate.Client, cfg *Config) {
 	}
 }
 
-func deleteUuidSlice(cfg *Config, client *weaviate.Client, slice []int) {
+func deleteUuidSlice(ctx context.Context, cfg *Config, client *weaviate.Client, slice []int) error {
 	log.WithFields(log.Fields{"length": len(slice), "class": cfg.ClassName}).Printf("Deleting objects to trigger tombstone operations")
 	for _, i := range slice {
-		err := client.Data().Deleter().WithClassName(cfg.ClassName).WithID(uuidFromInt(i)).Do(context.Background())
+		err := client.Data().Deleter().WithClassName(cfg.ClassName).WithID(uuidFromInt(i)).Do(ctx)
 		if err != nil {
-			log.Fatalf("Error deleting object: %v", err)
+			return fmt.Errorf("deleting object %d: %w", i, err)
 		}
 	}
 	log.WithFields(log.Fields{"length": len(slice), "class": cfg.ClassName}).Printf("Completed deletes")
+	return nil
 }
 
 func deleteUuidRange(cfg *Config, client *weaviate.Client, start int, end int) {
@@ -528,7 +529,9 @@ func deleteUuidRange(cfg *Config, client *weaviate.Client, start int, end int) {
 	for i := start; i < end; i++ {
 		slice = append(slice, i)
 	}
-	deleteUuidSlice(cfg, client, slice)
+	if err := deleteUuidSlice(context.Background(), cfg, client, slice); err != nil {
+		log.Fatalf("Error deleting object: %v", err)
+	}
 }
 
 func addTenantIfNeeded(cfg *Config, client *weaviate.Client) {

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -43,6 +43,8 @@ const (
 // Batch of vectors and offset for writing to Weaviate
 type Batch struct {
 	Vectors [][]float32
+	Text    []string // BM25/text import; parallel to Vectors (nil for pure-ANN batches)
+	Titles  []string // optional per-object title, parallel to Text
 	Offset  int
 	Filters []int
 }
@@ -98,9 +100,14 @@ func intFromUUID(uuidStr string) int {
 
 // Writes a single batch of vectors to Weaviate using gRPC
 func writeChunk(chunk *Batch, client *weaviategrpc.WeaviateClient, cfg *Config) {
-	objects := make([]*weaviategrpc.BatchObject, len(chunk.Vectors))
+	n := len(chunk.Vectors)
+	if n == 0 {
+		// Text-only (BM25) batches carry no vectors.
+		n = len(chunk.Text)
+	}
+	objects := make([]*weaviategrpc.BatchObject, n)
 
-	for i, vector := range chunk.Vectors {
+	for i := 0; i < n; i++ {
 		objects[i] = &weaviategrpc.BatchObject{
 			Uuid:       uuidFromInt(i + chunk.Offset + cfg.Offset),
 			Collection: cfg.ClassName,
@@ -108,42 +115,59 @@ func writeChunk(chunk *Batch, client *weaviategrpc.WeaviateClient, cfg *Config) 
 		if cfg.Tenant != "" {
 			objects[i].Tenant = cfg.Tenant
 		}
-		if cfg.MultiVectorDimensions > 0 {
-			if len(vector)%cfg.MultiVectorDimensions != 0 {
-				log.Fatalf("Vector length %d is not a multiple of dimensions %d",
-					len(vector), cfg.MultiVectorDimensions)
-			}
-			rows := len(vector) / cfg.MultiVectorDimensions
+		if i < len(chunk.Vectors) {
+			vector := chunk.Vectors[i]
+			if cfg.MultiVectorDimensions > 0 {
+				if len(vector)%cfg.MultiVectorDimensions != 0 {
+					log.Fatalf("Vector length %d is not a multiple of dimensions %d",
+						len(vector), cfg.MultiVectorDimensions)
+				}
+				rows := len(vector) / cfg.MultiVectorDimensions
 
-			multiVec := make([][]float32, rows)
-			for i := 0; i < rows; i++ {
-				start := i * cfg.MultiVectorDimensions
-				end := start + cfg.MultiVectorDimensions
-				multiVec[i] = vector[start:end]
+				multiVec := make([][]float32, rows)
+				for j := 0; j < rows; j++ {
+					start := j * cfg.MultiVectorDimensions
+					end := start + cfg.MultiVectorDimensions
+					multiVec[j] = vector[start:end]
+				}
+				name := "multivector"
+				if cfg.NamedVector != "" {
+					name = cfg.NamedVector
+				}
+				objects[i].Vectors = []*weaviategrpc.Vectors{{
+					Name:        name,
+					VectorBytes: byteops.Fp32SliceOfSlicesToBytes(multiVec),
+					Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
+				}}
+			} else if cfg.NamedVector != "" {
+				objects[i].Vectors = []*weaviategrpc.Vectors{{
+					Name:        cfg.NamedVector,
+					VectorBytes: encodeVector(vector),
+				}}
+			} else {
+				objects[i].VectorBytes = encodeVector(vector)
 			}
-			name := "multivector"
-			if cfg.NamedVector != "" {
-				name = cfg.NamedVector
+		}
+
+		// Object properties. For pure-ANN batches this only sets "category" when
+		// filtering is enabled (unchanged behavior). BM25/text batches add the
+		// searchable "text"/"title" properties plus a numeric "docId" used for
+		// range-based batch deletes during tombstone generation.
+		props := map[string]interface{}{}
+		if i < len(chunk.Text) {
+			props["text"] = chunk.Text[i]
+			props["docId"] = float64(i + chunk.Offset + cfg.Offset)
+			if i < len(chunk.Titles) {
+				props["title"] = chunk.Titles[i]
 			}
-			objects[i].Vectors = []*weaviategrpc.Vectors{{
-				Name:        name,
-				VectorBytes: byteops.Fp32SliceOfSlicesToBytes(multiVec),
-				Type:        weaviategrpc.Vectors_VECTOR_TYPE_MULTI_FP32,
-			}}
-		} else if cfg.NamedVector != "" {
-			objects[i].Vectors = []*weaviategrpc.Vectors{{
-				Name:        cfg.NamedVector,
-				VectorBytes: encodeVector(vector),
-			}}
-		} else {
-			objects[i].VectorBytes = encodeVector(vector)
 		}
 		if cfg.Filter {
-			nonRefProperties, err := structpb.NewStruct(map[string]interface{}{
-				"category": strconv.Itoa(chunk.Filters[i]),
-			})
+			props["category"] = strconv.Itoa(chunk.Filters[i])
+		}
+		if len(props) > 0 {
+			nonRefProperties, err := structpb.NewStruct(props)
 			if err != nil {
-				log.Fatalf("Error creating filtered struct: %v", err)
+				log.Fatalf("Error creating properties struct: %v", err)
 			}
 			objects[i].Properties = &weaviategrpc.BatchObject_Properties{
 				NonRefProperties: nonRefProperties,

--- a/benchmarker/cmd/ann_benchmark.go
+++ b/benchmarker/cmd/ann_benchmark.go
@@ -150,21 +150,22 @@ func writeChunk(chunk *Batch, client *weaviategrpc.WeaviateClient, cfg *Config) 
 		}
 
 		// Object properties. For pure-ANN batches this only sets "category" when
-		// filtering is enabled (unchanged behavior). BM25/text batches add the
-		// searchable "text"/"title" properties plus a numeric "docId" used for
-		// range-based batch deletes during tombstone generation.
-		props := map[string]interface{}{}
-		if i < len(chunk.Text) {
-			props["text"] = chunk.Text[i]
-			props["docId"] = float64(i + chunk.Offset + cfg.Offset)
-			if i < len(chunk.Titles) {
-				props["title"] = chunk.Titles[i]
+		// filtering is enabled (unchanged behavior — and no per-object allocation
+		// otherwise). BM25/text batches add the searchable "text"/"title"
+		// properties plus a numeric "docId" used for range-based batch deletes
+		// during tombstone generation.
+		if i < len(chunk.Text) || cfg.Filter {
+			props := map[string]interface{}{}
+			if i < len(chunk.Text) {
+				props["text"] = chunk.Text[i]
+				props["docId"] = float64(i + chunk.Offset + cfg.Offset)
+				if i < len(chunk.Titles) {
+					props["title"] = chunk.Titles[i]
+				}
 			}
-		}
-		if cfg.Filter {
-			props["category"] = strconv.Itoa(chunk.Filters[i])
-		}
-		if len(props) > 0 {
+			if cfg.Filter {
+				props["category"] = strconv.Itoa(chunk.Filters[i])
+			}
 			nonRefProperties, err := structpb.NewStruct(props)
 			if err != nil {
 				log.Fatalf("Error creating properties struct: %v", err)
@@ -512,10 +513,13 @@ func deleteChunk(chunk *Batch, client *weaviate.Client, cfg *Config) {
 	}
 }
 
+// deleteUuidSlice deletes the objects at the given zero-based corpus/dataset
+// indices. cfg.Offset is applied here (like writeChunk/deleteChunk) so callers
+// pass raw indices and --offset runs still target the objects they imported.
 func deleteUuidSlice(ctx context.Context, cfg *Config, client *weaviate.Client, slice []int) error {
 	log.WithFields(log.Fields{"length": len(slice), "class": cfg.ClassName}).Printf("Deleting objects to trigger tombstone operations")
 	for _, i := range slice {
-		err := client.Data().Deleter().WithClassName(cfg.ClassName).WithID(uuidFromInt(i)).Do(ctx)
+		err := client.Data().Deleter().WithClassName(cfg.ClassName).WithID(uuidFromInt(i + cfg.Offset)).Do(ctx)
 		if err != nil {
 			return fmt.Errorf("deleting object %d: %w", i, err)
 		}

--- a/benchmarker/cmd/beir_dataset.go
+++ b/benchmarker/cmd/beir_dataset.go
@@ -3,7 +3,11 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -27,12 +31,13 @@ type beirQuery struct {
 }
 
 // BeirDataset streams a BEIR-format text corpus (corpus.jsonl) into text batches
-// for import and loads the query set (queries.jsonl) for BM25 benchmarking.
+// for import and loads the query set (queries.jsonl) for BM25 benchmarking. When
+// quality measurement is enabled it also loads qrels and maps relevance judgments
+// onto document indices.
 //
 // It implements the Dataset interface so it can reuse the existing loadTrainData
 // import pipeline unchanged. BM25 benchmarking is vectorless, so the
-// vector-specific interface methods are no-ops. Qrels are intentionally ignored:
-// this is a performance benchmark, not a relevance evaluation.
+// vector-specific interface methods are no-ops.
 type BeirDataset struct {
 	corpusPath  string
 	queriesPath string
@@ -57,6 +62,35 @@ func NewBeirDataset(corpusPath, queriesPath string, useFilter bool, filterCount 
 	}
 }
 
+// scanCorpus iterates the non-empty lines of a JSONL corpus file, calling fn with
+// the document's ordinal index (0-based among non-empty lines) and the raw line.
+// The ordinal is exactly what uuidFromInt encodes at import, so every consumer
+// (StreamTrainData, NumTrainVectors, scanJudged) shares one definition of
+// "docIndex" and cannot drift on empty-line handling. fn returns false to stop.
+func scanCorpus(path string, fn func(idx int, line []byte) bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+
+	idx := 0
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if !fn(idx, line) {
+			return scanner.Err()
+		}
+		idx++
+	}
+	return scanner.Err()
+}
+
 // StreamTrainData reads corpus.jsonl and emits Batches of text objects. It honors
 // startOffset (skip the first N documents) and maxRecords (stop after N emitted
 // documents, 0 = all) so the same corpus can be re-streamed to reinsert a
@@ -64,19 +98,11 @@ func NewBeirDataset(corpusPath, queriesPath string, useFilter bool, filterCount 
 // corpus index of its first document, keeping generated UUIDs / docIds stable
 // across passes.
 func (d *BeirDataset) StreamTrainData(chunks chan<- Batch, batchSize, startOffset, maxRecords int) {
-	f, err := os.Open(d.corpusPath)
-	if err != nil {
-		log.Fatalf("Error opening corpus file %s: %v", d.corpusPath, err)
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
-
 	batchText := make([]string, 0, batchSize)
 	batchTitles := make([]string, 0, batchSize)
 	var batchFilters []int
 	batchStart := startOffset
+	emitted := 0
 
 	flush := func() {
 		if len(batchText) == 0 {
@@ -93,21 +119,13 @@ func (d *BeirDataset) StreamTrainData(chunks chan<- Batch, batchSize, startOffse
 		batchFilters = nil
 	}
 
-	idx := 0     // absolute position in the corpus file
-	emitted := 0 // documents emitted so far (after startOffset)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
+	err := scanCorpus(d.corpusPath, func(idx int, line []byte) bool {
 		if idx < startOffset {
-			idx++
-			continue
+			return true
 		}
 		if maxRecords > 0 && emitted >= maxRecords {
-			break
+			return false
 		}
-
 		var doc beirCorpusDoc
 		if err := json.Unmarshal(line, &doc); err != nil {
 			log.Fatalf("Error parsing corpus line %d: %v", idx, err)
@@ -117,23 +135,22 @@ func (d *BeirDataset) StreamTrainData(chunks chan<- Batch, batchSize, startOffse
 		if d.useFilter {
 			batchFilters = append(batchFilters, idx%d.filterCount)
 		}
-		idx++
 		emitted++
-
 		if len(batchText) >= batchSize {
 			flush()
-			batchStart = idx
+			batchStart = idx + 1
 		}
-	}
-	if err := scanner.Err(); err != nil {
+		return true
+	})
+	if err != nil {
 		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
 	}
 	flush()
 }
 
-// LoadQueries reads queries.jsonl and returns the query strings (the "text"
-// field of each line). Query IDs and qrels are ignored for performance testing.
-func (d *BeirDataset) LoadQueries() []string {
+// LoadQueriesWithIDs reads queries.jsonl and returns (id, text) pairs. Queries
+// with empty text are skipped.
+func (d *BeirDataset) LoadQueriesWithIDs() []beirQuery {
 	f, err := os.Open(d.queriesPath)
 	if err != nil {
 		log.Fatalf("Error opening queries file %s: %v", d.queriesPath, err)
@@ -143,7 +160,7 @@ func (d *BeirDataset) LoadQueries() []string {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
 
-	var queries []string
+	var queries []beirQuery
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -154,7 +171,7 @@ func (d *BeirDataset) LoadQueries() []string {
 			log.Fatalf("Error parsing query line: %v", err)
 		}
 		if q.Text != "" {
-			queries = append(queries, q.Text)
+			queries = append(queries, q)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -163,32 +180,119 @@ func (d *BeirDataset) LoadQueries() []string {
 	return queries
 }
 
+// LoadQueries returns just the query strings (throughput path).
+func (d *BeirDataset) LoadQueries() []string {
+	qs := d.LoadQueriesWithIDs()
+	out := make([]string, len(qs))
+	for i, q := range qs {
+		out[i] = q.Text
+	}
+	return out
+}
+
 // NumTrainVectors returns the number of documents in the corpus (non-empty
-// lines). The result is cached; the first call scans the file once. Used to
-// convert a tombstone percentage into an absolute document count.
+// lines). The result is cached; the first call scans the file once.
 func (d *BeirDataset) NumTrainVectors() int {
 	if d.corpusCount >= 0 {
 		return d.corpusCount
 	}
-	f, err := os.Open(d.corpusPath)
+	count := 0
+	err := scanCorpus(d.corpusPath, func(idx int, line []byte) bool {
+		count++
+		return true
+	})
 	if err != nil {
-		log.Fatalf("Error opening corpus file %s: %v", d.corpusPath, err)
+		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
+	}
+	d.corpusCount = count
+	return count
+}
+
+// LoadQrels parses a BEIR qrels TSV (columns: query-id, corpus-id, score) into
+// queryID -> docID -> grade. A header row is tolerated (skipped when the score
+// column of the first line does not parse as a number). IDs are kept as strings.
+func LoadQrels(path string) (map[string]map[string]int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
 	}
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
-	count := 0
+
+	qrels := make(map[string]map[string]int)
+	lineNum := 0
+	firstContent := true // header detection keys on the first NON-blank line
 	for scanner.Scan() {
-		if len(scanner.Bytes()) > 0 {
-			count++
+		lineNum++
+		line := strings.TrimRight(scanner.Text(), "\r\n")
+		if strings.TrimSpace(line) == "" {
+			continue
 		}
+		fields := strings.Split(line, "\t")
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("qrels line %d: expected 3 tab-separated columns (BEIR format), got %d", lineNum, len(fields))
+		}
+		qid, did, scoreStr := fields[0], fields[1], strings.TrimSpace(fields[2])
+		score, perr := strconv.ParseFloat(scoreStr, 64)
+		if perr != nil {
+			if firstContent {
+				firstContent = false
+				continue // header row
+			}
+			return nil, fmt.Errorf("qrels line %d: bad score %q: %v", lineNum, scoreStr, perr)
+		}
+		firstContent = false
+		if qrels[qid] == nil {
+			qrels[qid] = make(map[string]int)
+		}
+		qrels[qid][did] = int(score)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
+		return nil, err
 	}
-	d.corpusCount = count
-	return count
+	return qrels, nil
+}
+
+// scanJudged scans the corpus once and returns, for every doc-id present in
+// `judged`, its docIndex (matching import) and its content (for targeted
+// reinsertion during judged-doc-biased tombstone churn). Duplicate _ids are
+// warned about (they undercount recall).
+func (d *BeirDataset) scanJudged(judged map[string]bool) (idToIndex map[string]int, byIndex map[int]beirCorpusDoc, err error) {
+	idToIndex = make(map[string]int, len(judged))
+	byIndex = make(map[int]beirCorpusDoc, len(judged))
+	scanErr := scanCorpus(d.corpusPath, func(idx int, line []byte) bool {
+		var doc beirCorpusDoc
+		if uerr := json.Unmarshal(line, &doc); uerr != nil {
+			log.Fatalf("Error parsing corpus line %d: %v", idx, uerr)
+		}
+		if judged[doc.ID] {
+			if prev, dup := idToIndex[doc.ID]; dup {
+				log.Warnf("Duplicate corpus _id %q at indices %d and %d; recall may undercount", doc.ID, prev, idx)
+			}
+			idToIndex[doc.ID] = idx
+			byIndex[idx] = doc
+		}
+		return true
+	})
+	return idToIndex, byIndex, scanErr
+}
+
+// resolveQrelsPath returns the explicit --qrels path if set, otherwise
+// auto-detects <dir(corpus)>/qrels/test.tsv then .../dev.tsv. Returns "" if none.
+func resolveQrelsPath(corpusPath, qrelsFlag string) string {
+	if qrelsFlag != "" {
+		return qrelsFlag
+	}
+	dir := filepath.Dir(corpusPath)
+	for _, name := range []string{"test.tsv", "dev.tsv"} {
+		p := filepath.Join(dir, "qrels", name)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
 }
 
 // Dataset interface methods that are not meaningful for a vectorless BM25 corpus.

--- a/benchmarker/cmd/beir_dataset.go
+++ b/benchmarker/cmd/beir_dataset.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// beirMaxLineBytes bounds a single JSONL line. BEIR corpus documents (e.g. full
+// Wikipedia passages) routinely exceed bufio.Scanner's default 64KB limit, so we
+// raise it to avoid "token too long" errors mid-stream.
+const beirMaxLineBytes = 16 * 1024 * 1024
+
+// beirCorpusDoc mirrors one line of a BEIR corpus.jsonl file.
+type beirCorpusDoc struct {
+	ID    string `json:"_id"`
+	Title string `json:"title"`
+	Text  string `json:"text"`
+}
+
+// beirQuery mirrors one line of a BEIR queries.jsonl file.
+type beirQuery struct {
+	ID   string `json:"_id"`
+	Text string `json:"text"`
+}
+
+// BeirDataset streams a BEIR-format text corpus (corpus.jsonl) into text batches
+// for import and loads the query set (queries.jsonl) for BM25 benchmarking.
+//
+// It implements the Dataset interface so it can reuse the existing loadTrainData
+// import pipeline unchanged. BM25 benchmarking is vectorless, so the
+// vector-specific interface methods are no-ops. Qrels are intentionally ignored:
+// this is a performance benchmark, not a relevance evaluation.
+type BeirDataset struct {
+	corpusPath  string
+	queriesPath string
+	useFilter   bool
+	filterCount int
+	corpusCount int // cached line count; -1 until computed
+}
+
+// NewBeirDataset creates a loader for a BEIR dataset. When useFilter is set each
+// document is assigned a "category" bucket (index % filterCount) so BM25 queries
+// can be combined with a property filter of controllable selectivity.
+func NewBeirDataset(corpusPath, queriesPath string, useFilter bool, filterCount int) *BeirDataset {
+	if filterCount <= 0 {
+		filterCount = 1
+	}
+	return &BeirDataset{
+		corpusPath:  corpusPath,
+		queriesPath: queriesPath,
+		useFilter:   useFilter,
+		filterCount: filterCount,
+		corpusCount: -1,
+	}
+}
+
+// StreamTrainData reads corpus.jsonl and emits Batches of text objects. It honors
+// startOffset (skip the first N documents) and maxRecords (stop after N emitted
+// documents, 0 = all) so the same corpus can be re-streamed to reinsert a
+// document range during tombstone generation. Each batch's Offset is the absolute
+// corpus index of its first document, keeping generated UUIDs / docIds stable
+// across passes.
+func (d *BeirDataset) StreamTrainData(chunks chan<- Batch, batchSize, startOffset, maxRecords int) {
+	f, err := os.Open(d.corpusPath)
+	if err != nil {
+		log.Fatalf("Error opening corpus file %s: %v", d.corpusPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+
+	batchText := make([]string, 0, batchSize)
+	batchTitles := make([]string, 0, batchSize)
+	var batchFilters []int
+	batchStart := startOffset
+
+	flush := func() {
+		if len(batchText) == 0 {
+			return
+		}
+		chunks <- Batch{
+			Text:    batchText,
+			Titles:  batchTitles,
+			Filters: batchFilters,
+			Offset:  batchStart,
+		}
+		batchText = make([]string, 0, batchSize)
+		batchTitles = make([]string, 0, batchSize)
+		batchFilters = nil
+	}
+
+	idx := 0     // absolute position in the corpus file
+	emitted := 0 // documents emitted so far (after startOffset)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if idx < startOffset {
+			idx++
+			continue
+		}
+		if maxRecords > 0 && emitted >= maxRecords {
+			break
+		}
+
+		var doc beirCorpusDoc
+		if err := json.Unmarshal(line, &doc); err != nil {
+			log.Fatalf("Error parsing corpus line %d: %v", idx, err)
+		}
+		batchText = append(batchText, doc.Text)
+		batchTitles = append(batchTitles, doc.Title)
+		if d.useFilter {
+			batchFilters = append(batchFilters, idx%d.filterCount)
+		}
+		idx++
+		emitted++
+
+		if len(batchText) >= batchSize {
+			flush()
+			batchStart = idx
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
+	}
+	flush()
+}
+
+// LoadQueries reads queries.jsonl and returns the query strings (the "text"
+// field of each line). Query IDs and qrels are ignored for performance testing.
+func (d *BeirDataset) LoadQueries() []string {
+	f, err := os.Open(d.queriesPath)
+	if err != nil {
+		log.Fatalf("Error opening queries file %s: %v", d.queriesPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+
+	var queries []string
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var q beirQuery
+		if err := json.Unmarshal(line, &q); err != nil {
+			log.Fatalf("Error parsing query line: %v", err)
+		}
+		if q.Text != "" {
+			queries = append(queries, q.Text)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading queries file %s: %v", d.queriesPath, err)
+	}
+	return queries
+}
+
+// NumTrainVectors returns the number of documents in the corpus (non-empty
+// lines). The result is cached; the first call scans the file once. Used to
+// convert a tombstone percentage into an absolute document count.
+func (d *BeirDataset) NumTrainVectors() int {
+	if d.corpusCount >= 0 {
+		return d.corpusCount
+	}
+	f, err := os.Open(d.corpusPath)
+	if err != nil {
+		log.Fatalf("Error opening corpus file %s: %v", d.corpusPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), beirMaxLineBytes)
+	count := 0
+	for scanner.Scan() {
+		if len(scanner.Bytes()) > 0 {
+			count++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading corpus file %s: %v", d.corpusPath, err)
+	}
+	d.corpusCount = count
+	return count
+}
+
+// Dataset interface methods that are not meaningful for a vectorless BM25 corpus.
+func (d *BeirDataset) TestVectors() [][]float32 { return nil }
+func (d *BeirDataset) Neighbors() [][]int       { return nil }
+func (d *BeirDataset) TrainFilters() []int      { return nil }
+func (d *BeirDataset) TestFilters() []int       { return nil }
+func (d *BeirDataset) Dimension() int           { return 0 }
+func (d *BeirDataset) Close()                   {}

--- a/benchmarker/cmd/beir_dataset_test.go
+++ b/benchmarker/cmd/beir_dataset_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBeirFixture(t *testing.T, dir, name string, lines []string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", name, err)
+	}
+	return path
+}
+
+func drainBatches(ds *BeirDataset, batchSize, startOffset, maxRecords int) (offsets []int, texts, titles []string, filters []int) {
+	chunks := make(chan Batch, 16)
+	go func() {
+		ds.StreamTrainData(chunks, batchSize, startOffset, maxRecords)
+		close(chunks)
+	}()
+	for b := range chunks {
+		offsets = append(offsets, b.Offset)
+		texts = append(texts, b.Text...)
+		titles = append(titles, b.Titles...)
+		filters = append(filters, b.Filters...)
+	}
+	return offsets, texts, titles, filters
+}
+
+func TestBeirDatasetStreamAndQueries(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeBeirFixture(t, dir, "corpus.jsonl", []string{
+		`{"_id":"d0","title":"T0","text":"alpha beta"}`,
+		`{"_id":"d1","title":"T1","text":"gamma"}`,
+		`{"_id":"d2","title":"T2","text":"delta epsilon"}`,
+		`{"_id":"d3","title":"T3","text":"zeta"}`,
+		`{"_id":"d4","title":"T4","text":"eta"}`,
+	})
+	queries := writeBeirFixture(t, dir, "queries.jsonl", []string{
+		`{"_id":"q0","text":"alpha"}`,
+		`{"_id":"q1","text":"delta"}`,
+	})
+
+	ds := NewBeirDataset(corpus, queries, true, 2)
+
+	if got := ds.NumTrainVectors(); got != 5 {
+		t.Errorf("NumTrainVectors = %d, want 5", got)
+	}
+
+	offsets, texts, titles, filters := drainBatches(ds, 2, 0, 0)
+
+	wantTexts := []string{"alpha beta", "gamma", "delta epsilon", "zeta", "eta"}
+	if len(texts) != len(wantTexts) {
+		t.Fatalf("got %d texts, want %d", len(texts), len(wantTexts))
+	}
+	for i, w := range wantTexts {
+		if texts[i] != w {
+			t.Errorf("text[%d] = %q, want %q", i, texts[i], w)
+		}
+	}
+	wantTitles := []string{"T0", "T1", "T2", "T3", "T4"}
+	for i, w := range wantTitles {
+		if titles[i] != w {
+			t.Errorf("title[%d] = %q, want %q", i, titles[i], w)
+		}
+	}
+
+	// Filter buckets = absolute index % filterCount(2).
+	wantFilters := []int{0, 1, 0, 1, 0}
+	if len(filters) != len(wantFilters) {
+		t.Fatalf("got %d filters, want %d", len(filters), len(wantFilters))
+	}
+	for i, w := range wantFilters {
+		if filters[i] != w {
+			t.Errorf("filter[%d] = %d, want %d", i, filters[i], w)
+		}
+	}
+
+	// Batch offsets are the absolute corpus index of each batch's first doc.
+	wantOffsets := []int{0, 2, 4}
+	if len(offsets) != len(wantOffsets) {
+		t.Fatalf("got %d batches, want %d", len(offsets), len(wantOffsets))
+	}
+	for i, w := range wantOffsets {
+		if offsets[i] != w {
+			t.Errorf("offset[%d] = %d, want %d", i, offsets[i], w)
+		}
+	}
+
+	// Range re-stream (used by tombstone "update" reinsert): only the first 2 docs.
+	rangeOffsets, rangeTexts, _, _ := drainBatches(ds, 2, 0, 2)
+	if len(rangeTexts) != 2 {
+		t.Errorf("range restream got %d docs, want 2", len(rangeTexts))
+	}
+	if len(rangeOffsets) != 1 || rangeOffsets[0] != 0 {
+		t.Errorf("range restream offsets = %v, want [0]", rangeOffsets)
+	}
+
+	qs := ds.LoadQueries()
+	if len(qs) != 2 || qs[0] != "alpha" || qs[1] != "delta" {
+		t.Errorf("LoadQueries = %v, want [alpha delta]", qs)
+	}
+}

--- a/benchmarker/cmd/beir_dataset_test.go
+++ b/benchmarker/cmd/beir_dataset_test.go
@@ -9,6 +9,9 @@ import (
 
 func writeBeirFixture(t *testing.T, dir, name string, lines []string) string {
 	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatalf("write fixture %s: %v", name, err)

--- a/benchmarker/cmd/beir_qrels_test.go
+++ b/benchmarker/cmd/beir_qrels_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadQrels(t *testing.T) {
+	dir := t.TempDir()
+	path := writeBeirFixture(t, dir, "test.tsv", []string{
+		"query-id\tcorpus-id\tscore", // header, must be skipped
+		"q0\tMED-1\t2",
+		"q0\tMED-3\t1",
+		"q1\tMED-2\t1",
+		"q1\tMED-9\t0", // explicit non-relevant
+	})
+
+	qrels, err := LoadQrels(path)
+	if err != nil {
+		t.Fatalf("LoadQrels: %v", err)
+	}
+	if len(qrels) != 2 {
+		t.Fatalf("got %d queries, want 2", len(qrels))
+	}
+	if qrels["q0"]["MED-1"] != 2 || qrels["q0"]["MED-3"] != 1 {
+		t.Errorf("q0 grades = %v", qrels["q0"])
+	}
+	if qrels["q1"]["MED-2"] != 1 || qrels["q1"]["MED-9"] != 0 {
+		t.Errorf("q1 grades = %v", qrels["q1"])
+	}
+}
+
+func TestLoadQrelsBadColumns(t *testing.T) {
+	dir := t.TempDir()
+	path := writeBeirFixture(t, dir, "bad.tsv", []string{"q0\tMED-1"}) // only 2 cols, no header
+	if _, err := LoadQrels(path); err == nil {
+		t.Error("expected error for 2-column qrels line")
+	}
+}
+
+func TestResolveQrelsPath(t *testing.T) {
+	dir := t.TempDir()
+	corpus := filepath.Join(dir, "corpus.jsonl")
+
+	// explicit flag wins
+	if got := resolveQrelsPath(corpus, "/explicit/qrels.tsv"); got != "/explicit/qrels.tsv" {
+		t.Errorf("explicit = %q", got)
+	}
+	// none present
+	if got := resolveQrelsPath(corpus, ""); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+	// dev.tsv fallback
+	dev := writeBeirFixture(t, filepath.Join(dir, "qrels"), "dev.tsv", []string{"q0\tD-1\t1"})
+	if got := resolveQrelsPath(corpus, ""); got != dev {
+		t.Errorf("dev fallback = %q, want %q", got, dev)
+	}
+	// test.tsv preferred over dev.tsv
+	test := writeBeirFixture(t, filepath.Join(dir, "qrels"), "test.tsv", []string{"q0\tD-1\t1"})
+	if got := resolveQrelsPath(corpus, ""); got != test {
+		t.Errorf("test preferred = %q, want %q", got, test)
+	}
+}
+
+func TestScanJudged(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeBeirFixture(t, dir, "corpus.jsonl", []string{
+		`{"_id":"MED-0","title":"T0","text":"alpha"}`,
+		`{"_id":"MED-1","title":"T1","text":"beta"}`,
+		`{"_id":"MED-2","title":"T2","text":"gamma"}`,
+		`{"_id":"MED-3","title":"T3","text":"delta"}`,
+	})
+	ds := NewBeirDataset(corpus, "", false, 1)
+
+	judged := map[string]bool{"MED-1": true, "MED-3": true}
+	idToIndex, byIndex, err := ds.scanJudged(judged)
+	if err != nil {
+		t.Fatalf("scanJudged: %v", err)
+	}
+	// docIndex must match the import ordinal (uuidFromInt uses the same value).
+	if idToIndex["MED-1"] != 1 || idToIndex["MED-3"] != 3 {
+		t.Errorf("idToIndex = %v, want MED-1:1 MED-3:3", idToIndex)
+	}
+	if len(idToIndex) != 2 {
+		t.Errorf("idToIndex holds %d entries, want only judged (2)", len(idToIndex))
+	}
+	if byIndex[1].Text != "beta" || byIndex[3].Text != "delta" {
+		t.Errorf("byIndex content wrong: %v", byIndex)
+	}
+}

--- a/benchmarker/cmd/benchmark_quality_test.go
+++ b/benchmarker/cmd/benchmark_quality_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"math"
+	"testing"
+)
+
+func approxEqual(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func TestCalculateGradedNDCG(t *testing.T) {
+	tests := []struct {
+		name     string
+		ids      []int
+		relevant map[int]int
+		cutoff   int
+		want     float64
+	}{
+		{"perfect graded", []int{0, 1, 2}, map[int]int{0: 2, 1: 1}, 10, 1.0},
+		{"reversed", []int{1, 0}, map[int]int{0: 2, 1: 1}, 10, 2.2618595 / 2.6309298},
+		{"relevant lower down", []int{7, 8, 0, 1}, map[int]int{0: 2, 1: 1}, 10, (2.0/math.Log2(4) + 1.0/math.Log2(5)) / 2.6309298},
+		{"empty relevant", []int{0, 1}, map[int]int{}, 10, 0.0},
+		{"grade-0 ignored", []int{0}, map[int]int{0: 0, 1: 2}, 10, 0.0},
+		{"cutoff truncates", []int{5, 0}, map[int]int{0: 1, 5: 1}, 1, 1.0}, // only pos 0 (id5, rel) counted; IDCG@1=1
+		{"fewer results than cutoff", []int{0}, map[int]int{0: 1, 1: 1}, 10, (1.0) / (1.0 + 1.0/math.Log2(3))},
+	}
+	for _, tc := range tests {
+		got := calculateGradedNDCG(tc.ids, tc.relevant, tc.cutoff)
+		if !approxEqual(got, tc.want) {
+			t.Errorf("%s: NDCG = %.7f, want %.7f", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRecallVsRelevant(t *testing.T) {
+	tests := []struct {
+		name     string
+		ids      []int
+		relevant map[int]int
+		cutoff   int
+		want     float64
+	}{
+		{"partial", []int{0, 1, 9}, map[int]int{0: 1, 1: 1, 2: 1}, 10, 2.0 / 3.0},
+		{"cutoff limits found", []int{0, 1, 2}, map[int]int{0: 1, 1: 1, 2: 1}, 2, 2.0 / 3.0},
+		{"grade-0 not relevant", []int{0, 1}, map[int]int{0: 1, 1: 0}, 10, 1.0},
+		{"all found", []int{2, 1, 0}, map[int]int{0: 2, 1: 1, 2: 1}, 10, 1.0},
+		{"empty relevant", []int{0}, map[int]int{}, 10, 0.0},
+	}
+	for _, tc := range tests {
+		got := recallVsRelevant(tc.ids, tc.relevant, tc.cutoff)
+		if !approxEqual(got, tc.want) {
+			t.Errorf("%s: recall = %.7f, want %.7f", tc.name, got, tc.want)
+		}
+	}
+}

--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -209,11 +209,11 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 		}
 		took := time.Since(before)
 
-		// Only warn about a short result set when we have ground-truth neighbors to
-		// compare against (recall runs, e.g. ann-benchmark), where fewer than `limit`
-		// results signals a problem. For keyword/BM25 or random queries there is no
-		// ground truth and returning fewer than `limit` matches is normal.
-		if len(query.Neighbors) > 0 && len(searchReply.GetResults()) != cfg.Limit {
+		// Suppress the short-result warning only for BM25, where returning fewer than
+		// `limit` matches is normal (short/tombstoned posting lists). Vector-search
+		// commands (ann-benchmark, random-vectors, dataset, ...) keep the original
+		// behavior — a short result set there can signal a real problem.
+		if cfg.Mode != "bm25-benchmark" && len(searchReply.GetResults()) != cfg.Limit {
 			fmt.Printf("Warning grpc got %d results, expected %d\n", len(searchReply.GetResults()), cfg.Limit)
 		}
 

--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -357,6 +357,16 @@ func analyze(cfg Config, times []time.Duration, total time.Duration, recall []fl
 	out.Total = cfg.Queries
 	out.Failed = cfg.Queries - out.Successful
 	out.Parallelization = cfg.Parallel
+
+	// Reachable when every query in a pass errored (the quality-pass soft-fail
+	// records no timing then): return a zeroed result instead of dividing by zero.
+	if len(times) == 0 {
+		out.Min = 0
+		out.Took = total
+		out.Percentiles = make([]time.Duration, len(targetPercentiles))
+		return out
+	}
+
 	out.Mean = sum / time.Duration(len(times))
 	out.Took = total
 	out.QueriesPerSecond = float64(len(times)) / float64(float64(total)/float64(time.Second))

--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -29,6 +29,10 @@ import (
 type QueryWithNeighbors struct {
 	Query     []byte
 	Neighbors []int
+	// Relevance, when non-nil, switches recall/ndcg to graded IR metrics vs BEIR
+	// qrels (docIndex -> grade, relevant docs only) for the BM25 quality pass.
+	// It takes precedence over Neighbors; ANN leaves it nil.
+	Relevance map[int]int
 }
 
 func processQueueHttp(queue []QueryWithNeighbors, cfg *Config, c *http.Client, m *sync.Mutex, times *[]time.Duration) {
@@ -112,6 +116,61 @@ func calculateLinearNDCG(ids []int, neighbors []int, k int) float64 {
 	return score / perfectScore
 }
 
+// calculateGradedNDCG computes NDCG@cutoff for a result ranking `ids` against a
+// graded relevance map (docIndex -> grade, relevant docs only), using linear gain
+// and log2(rank+1) discount (the trec_eval / pytrec_eval / BEIR convention). The
+// DCG is computed over the delivered order; the ideal DCG (IDCG) uses the query's
+// grades sorted descending. Returns 0 when there are no relevant docs.
+func calculateGradedNDCG(ids []int, relevant map[int]int, cutoff int) float64 {
+	k := min(cutoff, len(ids))
+	dcg := 0.0
+	for p := 0; p < k; p++ {
+		if g, ok := relevant[ids[p]]; ok && g > 0 {
+			dcg += float64(g) / math.Log2(float64(p+2))
+		}
+	}
+
+	grades := make([]int, 0, len(relevant))
+	for _, g := range relevant {
+		if g > 0 {
+			grades = append(grades, g)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(grades)))
+
+	ik := min(cutoff, len(grades))
+	idcg := 0.0
+	for p := 0; p < ik; p++ {
+		idcg += float64(grades[p]) / math.Log2(float64(p+2))
+	}
+	if idcg == 0 {
+		return 0
+	}
+	return dcg / idcg
+}
+
+// recallVsRelevant computes Recall@cutoff = |top-cutoff ∩ relevant| / |relevant|
+// for a result ranking against a graded relevance map (grade > 0 = relevant).
+func recallVsRelevant(ids []int, relevant map[int]int, cutoff int) float64 {
+	totalRelevant := 0
+	for _, g := range relevant {
+		if g > 0 {
+			totalRelevant++
+		}
+	}
+	if totalRelevant == 0 {
+		return 0
+	}
+	k := min(cutoff, len(ids))
+	found := 0
+	for p := 0; p < k; p++ {
+		if g, ok := relevant[ids[p]]; ok && g > 0 {
+			found++
+		}
+	}
+	return float64(found) / float64(totalRelevant)
+}
+
 func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.ClientConn, m *sync.Mutex, times *[]time.Duration, recall *[]float64, ndcg *[]float64) {
 
 	grpcClient := wv1.NewWeaviateClient(grpcConn)
@@ -138,6 +197,14 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 
 		searchReply, err := grpcClient.Search(ctx, searchRequest)
 		if err != nil {
+			// The BM25 quality/settle pass re-runs many times right after a
+			// delete+reinsert, when a transient (mid-delete) gRPC error is most
+			// likely; soft-fail there so one blip doesn't abort the whole run. ANN
+			// and throughput passes (Relevance nil) keep the original fatal behavior.
+			if query.Relevance != nil {
+				log.Debugf("quality-pass search error (soft): %v", err)
+				continue
+			}
 			log.Fatalf("Could not search with grpc: %v", err)
 		}
 		took := time.Since(before)
@@ -157,7 +224,15 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 
 		m.Lock()
 		*times = append(*times, took)
-		if len(query.Neighbors) > 0 {
+		if query.Relevance != nil {
+			// BM25 quality pass: graded IR metrics vs qrels (NDCG@ndcgCutoff,
+			// Recall@recallCutoff), computed on the delivered order.
+			recallQuery := recallVsRelevant(ids, query.Relevance, cfg.RecallCutoff)
+			ndcgQuery := calculateGradedNDCG(ids, query.Relevance, cfg.NDCGCutoff)
+			log.Debugf("Query took %s, recall %f, ndcg %f (qrels)", took, recallQuery, ndcgQuery)
+			*recall = append(*recall, recallQuery)
+			*ndcg = append(*ndcg, ndcgQuery)
+		} else if len(query.Neighbors) > 0 {
 			neighborLimit := min(cfg.Limit, len(query.Neighbors))
 			recallQuery := float64(len(intersection(ids, query.Neighbors[:neighborLimit]))) / float64(neighborLimit)
 			ndcgQuery := calculateLinearNDCG(ids, query.Neighbors, neighborLimit)

--- a/benchmarker/cmd/benchmark_run.go
+++ b/benchmarker/cmd/benchmark_run.go
@@ -142,7 +142,11 @@ func processQueueGrpc(queue []QueryWithNeighbors, cfg *Config, grpcConn *grpc.Cl
 		}
 		took := time.Since(before)
 
-		if len(searchReply.GetResults()) != cfg.Limit {
+		// Only warn about a short result set when we have ground-truth neighbors to
+		// compare against (recall runs, e.g. ann-benchmark), where fewer than `limit`
+		// results signals a problem. For keyword/BM25 or random queries there is no
+		// ground truth and returning fewer than `limit` matches is normal.
+		if len(query.Neighbors) > 0 && len(searchReply.GetResults()) != cfg.Limit {
 			fmt.Printf("Warning grpc got %d results, expected %d\n", len(searchReply.GetResults()), cfg.Limit)
 		}
 

--- a/benchmarker/cmd/benchmark_run_test.go
+++ b/benchmarker/cmd/benchmark_run_test.go
@@ -194,3 +194,17 @@ func TestCalculateLinearNDCG(t *testing.T) {
 		})
 	}
 }
+
+// TestAnalyzeEmptyTimes locks the guard against an all-failed pass: the quality
+// soft-fail can leave times empty, which previously divided by zero in Mean.
+func TestAnalyzeEmptyTimes(t *testing.T) {
+	cfg := Config{Queries: 5, Parallel: 2}
+
+	out := analyze(cfg, nil, 3*time.Second, nil, nil)
+
+	require.Equal(t, 0, out.Successful)
+	require.Equal(t, 5, out.Failed)
+	require.Equal(t, time.Duration(0), out.Mean)
+	require.Equal(t, float64(0), out.QueriesPerSecond)
+	require.Len(t, out.Percentiles, len(targetPercentiles))
+}

--- a/benchmarker/cmd/bm25_benchmark.go
+++ b/benchmarker/cmd/bm25_benchmark.go
@@ -519,6 +519,12 @@ func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID,
 	if len(result.Percentiles) > 0 {
 		p99 = result.Percentiles[len(result.Percentiles)-1].Seconds()
 	}
+	// Query-only runs may carry no corpus; label the row by the query set instead
+	// of letting filepath.Base("") stamp an unhelpful ".".
+	datasetFile := cfg.CorpusFile
+	if datasetFile == "" {
+		datasetFile = cfg.QueriesFile
+	}
 	benchResult := ResultsJSONBenchmark{
 		Api:              cfg.API,
 		Mean:             result.Mean.Seconds(),
@@ -530,7 +536,7 @@ func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID,
 		ImportTime:       importTime.Seconds(),
 		RunID:            runID,
 		IterationRunID:   fmt.Sprintf("%d", iteration),
-		Dataset:          filepath.Base(cfg.CorpusFile),
+		Dataset:          filepath.Base(datasetFile),
 		Recall:           result.Recall,
 		NDCG:             result.NDCG,
 		Timestamp:        time.Now().Format(time.RFC3339),

--- a/benchmarker/cmd/bm25_benchmark.go
+++ b/benchmarker/cmd/bm25_benchmark.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -28,7 +30,9 @@ var bm25BenchmarkCommand = &cobra.Command{
 collection and benchmark BM25 keyword-search latency/QPS using queries.jsonl.
 
 Optionally generates inverted-index tombstones (via deletes/updates) to measure
-BM25 keyword-search performance under tombstone load.`,
+BM25 keyword-search performance under tombstone load, or sweeps a set of query
+limits (--limitArray) producing one result row per limit — the BM25 analog of
+the ANN ef sweep.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := globalConfig
 		cfg.Mode = "bm25-benchmark"
@@ -272,9 +276,30 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 	}
 
 	// Baseline (0 tombstones). Always run when there is no tombstone phase, so at
-	// least one measurement is produced.
+	// least one measurement is produced. With --limitArray the baseline becomes a
+	// sweep — one row per limit (the BM25 analog of the ANN ef sweep); validation
+	// guarantees no tombstone phases follow, so the limit column stays unique.
 	if cfg.MeasureBaseline || cfg.TombstonePercentage <= 0 {
-		measure("baseline", 0, 0, true, false)
+		limits := []int{cfg.Limit}
+		if cfg.LimitArray != "" {
+			parsed, err := parseLimitValues(cfg.LimitArray)
+			if err != nil {
+				fatal(err)
+			}
+			limits = parsed
+		}
+		for _, limit := range limits {
+			cfg.Limit = limit
+			if cfg.LimitArray != "" && quality != nil {
+				// Quality follows the swept limit (recall@k/ndcg@k per row). The
+				// quality pass retrieves q.depth results, frozen at construction
+				// from the cutoff flags — keep it in step with the cutoffs.
+				cfg.NDCGCutoff = limit
+				cfg.RecallCutoff = limit
+				quality.depth = limit
+			}
+			measure("baseline", 0, 0, true, false)
+		}
 	}
 
 	if cfg.TombstonePercentage > 0 {
@@ -349,6 +374,21 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 	}
 
 	writeBM25Results(cfg, runID, rows)
+}
+
+// parseLimitValues parses the --limitArray CSV into ints (the BM25 counterpart
+// of parseEfValues, kept separate so its errors name the right flag).
+func parseLimitValues(s string) ([]int, error) {
+	strs := strings.Split(s, ",")
+	nums := make([]int, len(strs))
+	for i, str := range strs {
+		num, err := strconv.Atoi(strings.TrimSpace(str))
+		if err != nil {
+			return nil, fmt.Errorf("error converting limitArray value '%s' to integer: %v", str, err)
+		}
+		nums[i] = num
+	}
+	return nums, nil
 }
 
 // benchmarkBM25 runs one pass (or cfg.Queries executions) of BM25 queries through
@@ -633,6 +673,7 @@ func initBM25Benchmark() {
 	f.IntVar(&globalConfig.Queries, "queries", 0, "Number of query executions per phase (0 = one pass over the query set)")
 	f.IntVar(&globalConfig.QueryDuration, "queryDuration", 0, "Query for the specified duration in seconds instead of a fixed count")
 	f.IntVarP(&globalConfig.Limit, "limit", "l", 10, "Query limit (top_k)")
+	f.StringVar(&globalConfig.LimitArray, "limitArray", "", "Comma-separated query limits to sweep, one result row per limit; overrides --limit and makes the quality cutoffs follow each swept limit. Incompatible with tombstone generation")
 	f.IntVarP(&globalConfig.Parallel, "parallel", "p", numCPU, "Number of parallel query threads")
 
 	// Filtering

--- a/benchmarker/cmd/bm25_benchmark.go
+++ b/benchmarker/cmd/bm25_benchmark.go
@@ -1,0 +1,514 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/filters"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+var bm25BenchmarkCommand = &cobra.Command{
+	Use:   "bm25-benchmark",
+	Short: "Benchmark BM25 keyword search on a BEIR-format text corpus",
+	Long: `Import a BEIR-format text corpus (corpus.jsonl) into a vectorless Weaviate
+collection and benchmark BM25 keyword-search latency/QPS using queries.jsonl.
+
+Optionally generates inverted-index tombstones (via deletes/updates) to measure
+BM25 keyword-search performance under tombstone load.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := globalConfig
+		cfg.Mode = "bm25-benchmark"
+
+		// All commands bind --className to the same globalConfig field, and pflag
+		// applies each command's default at registration time, so a later-registered
+		// command (colbert) clobbers this command's "Bm25Bench" default. Restore it
+		// when the user did not explicitly pass --className.
+		if !cmd.Flags().Changed("className") {
+			cfg.ClassName = "Bm25Bench"
+		}
+
+		if err := cfg.Validate(); err != nil {
+			fatal(err)
+		}
+		cfg.parseLabels()
+
+		memoryMonitor := NewMemoryMonitor(&cfg)
+		memoryMonitor.Start()
+		defer memoryMonitor.Stop()
+
+		ds := NewBeirDataset(cfg.CorpusFile, cfg.QueriesFile, cfg.Filter, cfg.FilterCount)
+		defer ds.Close()
+
+		client := createClient(&cfg)
+
+		var importTime time.Duration
+		if !cfg.QueryOnly {
+			if !cfg.ExistingSchema {
+				createBM25Schema(&cfg, client)
+			}
+			log.WithFields(log.Fields{
+				"class": cfg.ClassName, "corpus": cfg.CorpusFile, "filter": cfg.Filter,
+			}).Info("Starting BM25 import")
+			importTime = loadBM25Data(ds, &cfg, client)
+
+			sleepDuration := time.Duration(cfg.QueryDelaySeconds) * time.Second
+			log.Printf("Waiting for %s to allow flush/compaction to settle", sleepDuration)
+			time.Sleep(sleepDuration)
+		}
+
+		if cfg.SkipQuery {
+			return
+		}
+
+		queries := ds.LoadQueries()
+		if len(queries) == 0 {
+			fatal(fmt.Errorf("no queries loaded from %s", cfg.QueriesFile))
+		}
+		log.WithFields(log.Fields{"queries": len(queries)}).Info("Loaded BM25 queries")
+
+		runBM25Queries(&cfg, client, ds, queries, importTime)
+	},
+}
+
+// createBM25Schema (re)creates the benchmark collection: a vectorless class with a
+// searchable "text"/"title" property (BM25 inverted index), a numeric "docId"
+// (enables range-based batch deletes for tombstone generation), and an optional
+// filterable "category" property. NB: InvertedIndexConfig.CleanupIntervalSeconds
+// is deliberately not set — it is a no-op for inverted buckets in Weaviate.
+func createBM25Schema(cfg *Config, client *weaviate.Client) {
+	if err := client.Schema().ClassDeleter().WithClassName(cfg.ClassName).Do(context.Background()); err != nil {
+		log.Warnf("Error deleting class %s (may not exist yet): %v", cfg.ClassName, err)
+	}
+
+	tokenization := cfg.Tokenization
+	if tokenization == "" {
+		tokenization = "word"
+	}
+
+	properties := []*models.Property{
+		{
+			Name:            "text",
+			DataType:        []string{"text"},
+			Tokenization:    tokenization,
+			IndexSearchable: boolPtr(true),
+			IndexFilterable: boolPtr(false),
+		},
+		{
+			Name:            "title",
+			DataType:        []string{"text"},
+			Tokenization:    tokenization,
+			IndexSearchable: boolPtr(true),
+			IndexFilterable: boolPtr(false),
+		},
+		{
+			Name:            "docId",
+			DataType:        []string{"int"},
+			IndexFilterable: boolPtr(true),
+			IndexSearchable: boolPtr(false),
+		},
+	}
+	if cfg.Filter {
+		properties = append(properties, &models.Property{
+			Name:            "category",
+			DataType:        []string{"text"},
+			IndexFilterable: boolPtr(true),
+			IndexSearchable: boolPtr(false),
+		})
+	}
+
+	invertedIndexConfig := &models.InvertedIndexConfig{}
+	if cfg.BM25K1 > 0 || cfg.BM25B > 0 {
+		invertedIndexConfig.Bm25 = &models.BM25Config{
+			K1: float32(cfg.BM25K1),
+			B:  float32(cfg.BM25B),
+		}
+	}
+
+	classObj := &models.Class{
+		Class:               cfg.ClassName,
+		Description:         fmt.Sprintf("Created by the Weaviate BM25 Benchmarker at %s", time.Now().String()),
+		Vectorizer:          "none",
+		Properties:          properties,
+		InvertedIndexConfig: invertedIndexConfig,
+	}
+	if cfg.NumTenants > 0 {
+		classObj.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+	}
+	if cfg.Shards > 1 {
+		classObj.ShardingConfig = map[string]interface{}{"desiredCount": cfg.Shards}
+	}
+	if cfg.ReplicationFactor > 1 || cfg.AsyncReplicationEnabled {
+		classObj.ReplicationConfig = &models.ReplicationConfig{
+			Factor:       int64(cfg.ReplicationFactor),
+			AsyncEnabled: cfg.AsyncReplicationEnabled,
+		}
+	}
+
+	if err := client.Schema().ClassCreator().WithClass(classObj).Do(context.Background()); err != nil {
+		log.Fatalf("Error creating class %s: %v", cfg.ClassName, err)
+	}
+	log.Printf("Created BM25 class %s", cfg.ClassName)
+}
+
+// loadBM25Data imports the corpus using the shared 8-worker import pipeline. With
+// multi-tenancy it imports a full copy of the corpus into each tenant (mirroring
+// the ANN multi-tenant path). Tenant-scoped work uses local Config copies so the
+// shared cfg is never mutated.
+func loadBM25Data(ds *BeirDataset, cfg *Config, client *weaviate.Client) time.Duration {
+	start := time.Now()
+	if cfg.NumTenants > 0 {
+		for i := 0; i < cfg.NumTenants; i++ {
+			tenantCfg := *cfg
+			tenantCfg.Tenant = fmt.Sprintf("%d", i)
+			addTenantIfNeeded(&tenantCfg, client)
+			loadTrainData(ds, &tenantCfg, 0, 0, 0)
+		}
+	} else {
+		loadTrainData(ds, cfg, 0, 0, 0)
+	}
+	elapsed := time.Since(start)
+	log.WithFields(log.Fields{"duration": elapsed, "tenants": cfg.NumTenants}).Printf("BM25 import complete")
+	return elapsed
+}
+
+// runBM25Queries runs the phased measurement (baseline, then tombstone phases if
+// requested) and writes one labeled result row per phase to ./results/{runID}.json.
+func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queries []string, importTime time.Duration) {
+	runID := fmt.Sprintf("%d", time.Now().Unix())
+	var rows []map[string]interface{}
+
+	measure := func(phase string, iteration int, tombstoneRatio float64) {
+		var result Results
+		if cfg.QueryDuration > 0 {
+			result = benchmarkBM25Duration(*cfg, queries)
+		} else {
+			result = benchmarkBM25(*cfg, queries)
+		}
+		log.WithFields(log.Fields{
+			"phase": phase, "iteration": iteration, "tombstoneRatio": tombstoneRatio,
+			"mean": result.Mean, "qps": result.QueriesPerSecond,
+			"parallel": cfg.Parallel, "limit": cfg.Limit, "failed": result.Failed,
+		}).Infof("BM25 %s result", phase)
+		if _, err := result.WriteTextTo(os.Stdout); err != nil {
+			log.Warnf("Error writing results to stdout: %v", err)
+		}
+		rows = append(rows, bm25ResultRow(cfg, result, importTime, runID, phase, iteration, tombstoneRatio))
+	}
+
+	// Baseline (0 tombstones). Always run when there is no tombstone phase, so at
+	// least one measurement is produced.
+	if cfg.MeasureBaseline || cfg.TombstonePercentage <= 0 {
+		measure("baseline", 0, 0)
+	}
+
+	if cfg.TombstonePercentage > 0 {
+		total := ds.NumTrainVectors()
+		k := int(math.Floor(cfg.TombstonePercentage * float64(total)))
+		if k < 1 {
+			k = 1
+		}
+		iterations := cfg.TombstoneIterations
+		if iterations < 1 {
+			iterations = 1
+		}
+
+		if cfg.TombstoneConcurrent {
+			// Sustain churn in the background while a single query window runs.
+			stop := make(chan struct{})
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						generateTombstones(cfg, client, ds, k)
+					}
+				}
+			}()
+			measure("concurrent", 0, cfg.TombstonePercentage)
+			close(stop)
+			<-done
+		} else {
+			for it := 1; it <= iterations; it++ {
+				generateTombstones(cfg, client, ds, k)
+				measure("tombstoned", it, cfg.TombstonePercentage*float64(it))
+			}
+		}
+	}
+
+	writeBM25Results(cfg, runID, rows)
+}
+
+// benchmarkBM25 runs one pass (or cfg.Queries executions) of BM25 queries through
+// the shared worker-pool harness. Neighbors are left empty so recall/NDCG are
+// skipped (this is a pure performance test).
+func benchmarkBM25(cfg Config, queries []string) Results {
+	if cfg.Queries == 0 {
+		cfg.Queries = len(queries)
+	}
+	i := 0
+	return benchmark(cfg, func(className string) QueryWithNeighbors {
+		query := queries[i%len(queries)]
+		i++
+		tenant := cfg.Tenant
+		if cfg.NumTenants > 0 {
+			tenant = fmt.Sprintf("%d", rand.Intn(cfg.NumTenants))
+		}
+		filter := -1
+		if cfg.Filter && cfg.FilterCount > 0 {
+			filter = rand.Intn(cfg.FilterCount)
+		}
+		return QueryWithNeighbors{
+			Query: bm25QueryGrpc(&cfg, query, tenant, filter),
+		}
+	})
+}
+
+// benchmarkBM25Duration repeats benchmarkBM25 for cfg.QueryDuration seconds and
+// returns the median across runs (mirrors benchmarkANNDuration).
+func benchmarkBM25Duration(cfg Config, queries []string) Results {
+	var samples sampledResults
+	startTime := time.Now()
+	var results Results
+	iterations := 0
+	for time.Since(startTime) < time.Duration(cfg.QueryDuration)*time.Second {
+		results = benchmarkBM25(cfg, queries)
+		samples.Min = append(samples.Min, results.Min)
+		samples.Max = append(samples.Max, results.Max)
+		samples.Mean = append(samples.Mean, results.Mean)
+		samples.Took = append(samples.Took, results.Took)
+		samples.QueriesPerSecond = append(samples.QueriesPerSecond, results.QueriesPerSecond)
+		samples.Results = append(samples.Results, results)
+		iterations++
+	}
+
+	var medianResult Results
+	medianResult.Min = time.Duration(median(samples.Min))
+	medianResult.Max = time.Duration(median(samples.Max))
+	medianResult.Mean = time.Duration(median(samples.Mean))
+	medianResult.Took = time.Duration(median(samples.Took))
+	medianResult.QueriesPerSecond = median(samples.QueriesPerSecond)
+	medianResult.Percentiles = results.Percentiles
+	medianResult.PercentilesLabels = results.PercentilesLabels
+	medianResult.Total = results.Total
+	medianResult.Successful = results.Successful
+	medianResult.Failed = results.Failed
+	medianResult.Parallelization = cfg.Parallel
+
+	log.WithFields(log.Fields{"iterations": iterations}).Infof("Queried for %d seconds", cfg.QueryDuration)
+	return medianResult
+}
+
+// generateTombstones creates inverted-index tombstones for the first k documents
+// (docId < k). Under multi-tenancy each tenant has its own inverted index, so it
+// churns every tenant. It never mutates the shared cfg (it passes per-tenant
+// Config copies), which keeps it safe to run concurrently with the query phase.
+func generateTombstones(cfg *Config, client *weaviate.Client, ds *BeirDataset, k int) {
+	if cfg.NumTenants > 0 {
+		for i := 0; i < cfg.NumTenants; i++ {
+			tombstoneOnce(*cfg, client, ds, k, fmt.Sprintf("%d", i))
+		}
+		return
+	}
+	tombstoneOnce(*cfg, client, ds, k, cfg.Tenant)
+}
+
+// tombstoneOnce deletes docId < k in a single tenant (empty tenant = single-tenant
+// mode). In "update" mode it reinserts those same documents (identical UUIDs +
+// docIds) so the corpus size holds and each old docID becomes a fresh tombstone —
+// matching an update-heavy workload. cfg is taken by value so the tenant
+// assignment stays local.
+func tombstoneOnce(cfg Config, client *weaviate.Client, ds *BeirDataset, k int, tenant string) {
+	cfg.Tenant = tenant
+	deleted := batchDeleteDocIDRange(&cfg, client, k)
+	log.WithFields(log.Fields{
+		"deleted": deleted, "mode": cfg.TombstoneMode, "range": k, "tenant": tenant,
+	}).Printf("Generated tombstones")
+
+	if cfg.TombstoneMode == "delete" {
+		return
+	}
+	// Default ("update"): reinsert the same document range.
+	loadTrainData(ds, &cfg, 0, uint(k), 0)
+}
+
+// batchDeleteDocIDRange deletes all objects with docId < end, looping because the
+// server deletes at most QUERY_MAXIMUM_RESULTS (~10k) objects per call. Returns
+// the total number of objects deleted.
+func batchDeleteDocIDRange(cfg *Config, client *weaviate.Client, end int) int64 {
+	where := filters.Where().
+		WithPath([]string{"docId"}).
+		WithOperator(filters.LessThan).
+		WithValueInt(int64(end))
+
+	var total int64
+	for {
+		deleter := client.Batch().ObjectsBatchDeleter().
+			WithClassName(cfg.ClassName).
+			WithWhere(where).
+			WithOutput("minimal")
+		if cfg.Tenant != "" {
+			deleter = deleter.WithTenant(cfg.Tenant)
+		}
+		resp, err := deleter.Do(context.Background())
+		if err != nil {
+			log.Fatalf("Error batch-deleting objects for tombstones: %v", err)
+		}
+		if resp.Results == nil || resp.Results.Successful == 0 {
+			break
+		}
+		total += resp.Results.Successful
+	}
+	return total
+}
+
+// bm25ResultRow builds one JSON result row, reusing the ANN-compatible
+// ResultsJSONBenchmark shape and adding BM25/tombstone-specific fields plus any
+// user --labels, so runs remain ingestible by weaviate-performance-tests.
+func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID, phase string, iteration int, tombstoneRatio float64) map[string]interface{} {
+	p99 := 0.0
+	if len(result.Percentiles) > 0 {
+		p99 = result.Percentiles[len(result.Percentiles)-1].Seconds()
+	}
+	benchResult := ResultsJSONBenchmark{
+		Api:              cfg.API,
+		Mean:             result.Mean.Seconds(),
+		P99Latency:       p99,
+		QueriesPerSecond: result.QueriesPerSecond,
+		Shards:           cfg.Shards,
+		Parallelization:  cfg.Parallel,
+		Limit:            cfg.Limit,
+		ImportTime:       importTime.Seconds(),
+		RunID:            runID,
+		IterationRunID:   fmt.Sprintf("%d", iteration),
+		Dataset:          filepath.Base(cfg.CorpusFile),
+		Timestamp:        time.Now().Format(time.RFC3339),
+	}
+
+	jsonData, err := json.Marshal(benchResult)
+	if err != nil {
+		log.Fatalf("Error converting result to json: %v", err)
+	}
+	var row map[string]interface{}
+	if err := json.Unmarshal(jsonData, &row); err != nil {
+		log.Fatalf("Error converting json to map: %v", err)
+	}
+
+	row["phase"] = phase
+	row["tombstoneRatio"] = tombstoneRatio
+	row["tombstoneMode"] = cfg.TombstoneMode
+	row["bm25Operator"] = cfg.BM25Operator
+	row["queryProperties"] = cfg.QueryProperties
+	row["bm25k1"] = cfg.BM25K1
+	row["bm25b"] = cfg.BM25B
+	if cfg.Filter {
+		row["filterCount"] = cfg.FilterCount
+	}
+	for key, value := range cfg.LabelMap {
+		row[key] = value
+	}
+	return row
+}
+
+func writeBM25Results(cfg *Config, runID string, rows []map[string]interface{}) {
+	if len(rows) == 0 {
+		return
+	}
+	data, err := json.MarshalIndent(rows, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling benchmark results: %v", err)
+	}
+
+	if err := os.MkdirAll("./results", 0o755); err != nil {
+		log.Fatalf("Error creating results directory: %v", err)
+	}
+	path := fmt.Sprintf("./results/%s.json", runID)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		log.Fatalf("Error writing benchmark results to file: %v", err)
+	}
+	log.Printf("Wrote BM25 results to %s", path)
+
+	if cfg.OutputFile != "" {
+		if err := os.WriteFile(cfg.OutputFile, data, 0o644); err != nil {
+			log.Warnf("Error writing to output file %s: %v", cfg.OutputFile, err)
+		}
+	}
+}
+
+func initBM25Benchmark() {
+	rootCmd.AddCommand(bm25BenchmarkCommand)
+
+	numCPU := runtime.NumCPU()
+	f := bm25BenchmarkCommand.PersistentFlags()
+
+	// Dataset & schema
+	f.StringVar(&globalConfig.CorpusFile, "corpus", "", "Path to the BEIR corpus.jsonl file (required unless --query)")
+	f.StringVar(&globalConfig.QueriesFile, "queriesFile", "", "Path to the BEIR queries.jsonl file (required)")
+	f.StringVarP(&globalConfig.ClassName, "className", "c", "Bm25Bench", "Class name for the benchmark collection")
+	f.StringVar(&globalConfig.Tokenization, "tokenization", "word", "Tokenization for the text properties (word, lowercase, whitespace, field, trigram)")
+	f.Float64Var(&globalConfig.BM25K1, "bm25k1", 1.2, "BM25 k1 parameter")
+	f.Float64Var(&globalConfig.BM25B, "bm25b", 0.75, "BM25 b parameter")
+
+	// Query behavior
+	f.StringVar(&globalConfig.SearchType, "searchType", "bm25", "Search type (bm25; hybrid reserved for a future version)")
+	f.StringVar(&globalConfig.QueryProperties, "queryProperties", "text", "Comma-separated properties to run BM25 against")
+	f.StringVar(&globalConfig.BM25Operator, "bm25Operator", "", "BM25 search operator: or, and, or empty for server default")
+	f.IntVar(&globalConfig.MinOrTokens, "minimumOrTokensMatch", 0, "minimumOrTokensMatch for the OR operator (0 = unset)")
+	f.IntVar(&globalConfig.Queries, "queries", 0, "Number of query executions per phase (0 = one pass over the query set)")
+	f.IntVar(&globalConfig.QueryDuration, "queryDuration", 0, "Query for the specified duration in seconds instead of a fixed count")
+	f.IntVarP(&globalConfig.Limit, "limit", "l", 10, "Query limit (top_k)")
+	f.IntVarP(&globalConfig.Parallel, "parallel", "p", numCPU, "Number of parallel query threads")
+
+	// Filtering
+	f.BoolVar(&globalConfig.Filter, "filter", false, "Combine BM25 with an equality filter on a category bucket")
+	f.IntVar(&globalConfig.FilterCount, "filterCount", 10, "Number of category buckets (filter selectivity = 1/filterCount)")
+
+	// Tombstone generation
+	f.Float64Var(&globalConfig.TombstonePercentage, "tombstonePercentage", 0.0, "Fraction of docs (0..1) to tombstone per iteration (0 disables)")
+	f.StringVar(&globalConfig.TombstoneMode, "tombstoneMode", "update", "How to create tombstones: update (delete+reinsert) or delete")
+	f.IntVar(&globalConfig.TombstoneIterations, "tombstoneIterations", 1, "Number of tombstone-generation iterations (re-measured each time)")
+	f.BoolVar(&globalConfig.TombstoneConcurrent, "tombstoneConcurrent", false, "Churn tombstones in the background during the query run")
+	f.BoolVar(&globalConfig.MeasureBaseline, "measureBaseline", true, "Run a 0-tombstone baseline before the tombstone phase")
+
+	// Import & topology
+	f.IntVarP(&globalConfig.BatchSize, "batchSize", "b", 1000, "Batch size for import")
+	f.IntVar(&globalConfig.NumTenants, "numTenants", 0, "Number of tenants; each gets a full corpus copy (0 = single-tenant)")
+	f.IntVar(&globalConfig.Shards, "shards", 1, "Number of shards")
+	f.IntVar(&globalConfig.ReplicationFactor, "replicationFactor", 1, "Replication factor")
+
+	// Connection & output
+	f.StringVarP(&globalConfig.Origin, "grpcOrigin", "u", "localhost:50051", "The gRPC origin that Weaviate is running at")
+	f.StringVar(&globalConfig.HttpOrigin, "httpOrigin", "localhost:8080", "The HTTP origin for Weaviate")
+	f.StringVar(&globalConfig.HttpScheme, "httpScheme", "http", "The HTTP scheme (http or https)")
+	f.StringVarP(&globalConfig.API, "api", "a", "grpc", "API to use (only grpc is supported)")
+	f.StringVar(&globalConfig.Labels, "labels", "", "Labels of format key1=value1,key2=value2 merged into each result row")
+	f.StringVarP(&globalConfig.OutputFormat, "format", "f", "text", "Output format, one of [text, json]")
+	f.StringVarP(&globalConfig.OutputFile, "output", "o", "", "Optional output file for the results JSON")
+
+	// Lifecycle / skip options
+	f.BoolVar(&globalConfig.QueryOnly, "query", false, "Do not import; query an existing collection")
+	f.BoolVar(&globalConfig.SkipQuery, "skipQuery", false, "Only import data, skip the query phase")
+	f.BoolVar(&globalConfig.ExistingSchema, "existingSchema", false, "Leave the schema as-is (do not recreate the class)")
+	f.IntVar(&globalConfig.QueryDelaySeconds, "queryDelaySeconds", 30, "How long to wait after import before querying")
+
+	// Memory monitoring
+	f.StringVar(&globalConfig.MetricsEndpoint, "metricsEndpoint", "http://localhost:2112/metrics", "Weaviate metrics endpoint")
+	f.BoolVar(&globalConfig.MemoryMonitoringEnabled, "memoryMonitoringEnabled", false, "Enable continuous memory monitoring")
+	f.IntVar(&globalConfig.MemoryMonitoringInterval, "memoryMonitoringInterval", 5, "Memory monitoring interval in seconds")
+	f.StringVar(&globalConfig.MemoryMonitoringFile, "memoryMonitoringFile", "", "Memory monitoring output file")
+}

--- a/benchmarker/cmd/bm25_benchmark.go
+++ b/benchmarker/cmd/bm25_benchmark.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -199,7 +200,12 @@ func loadBM25Data(ds *BeirDataset, cfg *Config, client *weaviate.Client) time.Du
 // retrievability probe.
 func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queries []string, importTime time.Duration, quality *bm25Quality) {
 	runID := fmt.Sprintf("%d", time.Now().Unix())
-	corpusDocs := ds.NumTrainVectors()
+	// Query-only mode may run without --corpus (tombstones and quality both
+	// validate that a corpus is present), so only count docs when we have one.
+	corpusDocs := 0
+	if cfg.CorpusFile != "" {
+		corpusDocs = ds.NumTrainVectors()
+	}
 	var rows []map[string]interface{}
 
 	// measure runs the throughput pass and (when withQuality) a separate quality
@@ -215,10 +221,24 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 			result = benchmarkBM25(*cfg, queries)
 		}
 		retrievability := -1.0
+		qualityFailed := -1
+		qualityMeasured := false
 		if withQuality && quality != nil {
 			qr := stableQuality(*cfg, quality, 180*time.Second)
-			result.Recall = qr.Recall
-			result.NDCG = qr.NDCG
+			if qr.Successful == 0 {
+				// Every quality query errored (e.g. cluster unreachable mid-churn):
+				// a 0.0 here is an artifact, not a measurement. Omit the quality
+				// fields so downstream thresholds never read it as a real collapse.
+				log.Errorf("quality pass had no successful queries (failed=%d) — omitting recall/ndcg from the %s row", qr.Failed, phase)
+			} else {
+				if qr.Failed > 0 {
+					log.Warnf("quality pass: %d/%d queries failed; recall/ndcg averaged over the %d successful", qr.Failed, qr.Total, qr.Successful)
+				}
+				result.Recall = qr.Recall
+				result.NDCG = qr.NDCG
+				qualityFailed = qr.Failed
+				qualityMeasured = true
+			}
 			if isTombstone && cfg.TombstoneMode != "delete" {
 				retrievability = tombstoneRetrievability(cfg, quality, 100)
 			}
@@ -232,14 +252,14 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 			log.Warnf("Error writing results to stdout: %v", err)
 		}
 		// Only attach the quality labels (benchmarkType=bm25-qrels, cutoffs, ...) to
-		// rows where quality was actually measured; the concurrent phase skips it, so
-		// its row stays a pure latency-under-churn row (no misleading recall=0 on a
-		// bm25-qrels-labeled row).
+		// rows where quality was actually measured; the concurrent phase skips it and
+		// an all-failed quality pass omits them, so those rows stay pure
+		// latency-under-churn rows (no misleading recall=0 on a bm25-qrels row).
 		qualityForRow := quality
-		if !withQuality {
+		if !qualityMeasured {
 			qualityForRow = nil
 		}
-		rows = append(rows, bm25ResultRow(cfg, result, importTime, runID, phase, iteration, tombstoneRatio, qualityForRow, retrievability, corpusDocs))
+		rows = append(rows, bm25ResultRow(cfg, result, importTime, runID, phase, iteration, tombstoneRatio, qualityForRow, qualityFailed, retrievability, corpusDocs))
 	}
 
 	// In quality mode, wait for the freshly-imported corpus to be searchable before
@@ -267,10 +287,20 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 			iterations = 1
 		}
 
+		// Judged-doc churn (quality mode, update churn) replaces the docId<k range
+		// churn inside tombstoneOnce, so the fraction actually churned is the judged
+		// set — record that on the rows, not the nominal --tombstonePercentage.
+		churnFraction := cfg.TombstonePercentage
+		if usesJudgedChurn(cfg.TombstoneMode, quality) && corpusDocs > 0 {
+			churnFraction = float64(len(quality.relevantIdx)) / float64(corpusDocs)
+		}
+
 		if cfg.TombstoneConcurrent {
 			// Sustain churn in the background while a single query window runs.
 			// Quality is skipped here: the index is moving, so a qrels number would
 			// be a noisy snapshot, not a stable gate value.
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			stop := make(chan struct{})
 			done := make(chan struct{})
 			go func() {
@@ -280,16 +310,31 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 					case <-stop:
 						return
 					default:
-						generateTombstones(cfg, client, ds, k, quality)
+						if err := generateTombstones(ctx, cfg, client, ds, k, quality); err != nil {
+							if !errors.Is(err, context.Canceled) {
+								log.Errorf("background tombstone churn stopped: %v", err)
+							}
+							return
+						}
 					}
 				}
 			}()
-			measure("concurrent", 0, cfg.TombstonePercentage, false, false)
+			measure("concurrent", 0, churnFraction, false, false)
 			close(stop)
-			<-done
+			cancel() // interrupt any in-flight churn RPC so the join can't hang
+			select {
+			case <-done:
+			case <-time.After(2 * time.Minute):
+				// The only uncancellable churn call is the shared import pipeline
+				// (loadTrainData); don't let a hung server discard the results.
+				log.Warnf("background churn did not stop within 2m; writing results without waiting")
+			}
 		} else {
 			for it := 1; it <= iterations; it++ {
-				generateTombstones(cfg, client, ds, k, quality)
+				if err := generateTombstones(context.Background(), cfg, client, ds, k, quality); err != nil {
+					log.Errorf("tombstone churn failed on iteration %d: %v — keeping rows collected so far", it, err)
+					break
+				}
 				// Wait for the reinserted docs to become searchable before measuring
 				// quality: their reindex can lag on a multi-node cluster, and that
 				// transient window must not be read as a regression. A real bug (docs
@@ -298,7 +343,7 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 				if quality != nil && cfg.TombstoneMode != "delete" {
 					waitRetrievable(cfg, quality, 0.99, 5*time.Minute)
 				}
-				measure("tombstoned", it, cfg.TombstonePercentage*float64(it), true, true)
+				measure("tombstoned", it, churnFraction*float64(it), true, true)
 			}
 		}
 	}
@@ -370,14 +415,23 @@ func benchmarkBM25Duration(cfg Config, queries []string) Results {
 // (docId < k). Under multi-tenancy each tenant has its own inverted index, so it
 // churns every tenant. It never mutates the shared cfg (it passes per-tenant
 // Config copies), which keeps it safe to run concurrently with the query phase.
-func generateTombstones(cfg *Config, client *weaviate.Client, ds *BeirDataset, k int, quality *bm25Quality) {
+func generateTombstones(ctx context.Context, cfg *Config, client *weaviate.Client, ds *BeirDataset, k int, quality *bm25Quality) error {
 	if cfg.NumTenants > 0 {
 		for i := 0; i < cfg.NumTenants; i++ {
-			tombstoneOnce(*cfg, client, ds, k, fmt.Sprintf("%d", i), quality)
+			if err := tombstoneOnce(ctx, *cfg, client, ds, k, fmt.Sprintf("%d", i), quality); err != nil {
+				return err
+			}
 		}
-		return
+		return nil
 	}
-	tombstoneOnce(*cfg, client, ds, k, cfg.Tenant, quality)
+	return tombstoneOnce(ctx, *cfg, client, ds, k, cfg.Tenant, quality)
+}
+
+// usesJudgedChurn reports whether tombstone churn targets the judged (relevant)
+// docs instead of the docId<k range — quality mode with update churn. Shared by
+// tombstoneOnce (branch) and runBM25Queries (row labeling) so they cannot drift.
+func usesJudgedChurn(tombstoneMode string, quality *bm25Quality) bool {
+	return quality != nil && tombstoneMode != "delete" && len(quality.relevantIdx) > 0
 }
 
 // tombstoneOnce creates tombstones in a single tenant (empty tenant = single-tenant
@@ -390,7 +444,7 @@ func generateTombstones(cfg *Config, client *weaviate.Client, ds *BeirDataset, k
 // than docId<k, so a tombstone-handling bug actually moves NDCG/Recall (on a large
 // corpus the first-k docs are otherwise disjoint from the judged set). Quality mode
 // is single-tenant, so this path never runs multi-tenant.
-func tombstoneOnce(cfg Config, client *weaviate.Client, ds *BeirDataset, k int, tenant string, quality *bm25Quality) {
+func tombstoneOnce(ctx context.Context, cfg Config, client *weaviate.Client, ds *BeirDataset, k int, tenant string, quality *bm25Quality) error {
 	cfg.Tenant = tenant
 
 	// Judged-doc-biased churn only applies to update mode: delete+reinsert the
@@ -399,31 +453,39 @@ func tombstoneOnce(cfg Config, client *weaviate.Client, ds *BeirDataset, k int, 
 	// churn (it does NOT delete judged docs), so delete-mode quality does not
 	// exercise relevance churn — it just measures quality after deleting the first k
 	// (mostly non-judged) docs.
-	if quality != nil && cfg.TombstoneMode != "delete" && len(quality.relevantIdx) > 0 {
-		deleteUuidSlice(&cfg, client, quality.relevantIdx)
-		reinsertDocs(&cfg, quality.relevantDocs)
+	if usesJudgedChurn(cfg.TombstoneMode, quality) {
+		if err := deleteUuidSlice(ctx, &cfg, client, quality.relevantIdx); err != nil {
+			return fmt.Errorf("judged-doc delete: %w", err)
+		}
+		if err := reinsertDocs(ctx, &cfg, quality.relevantDocs); err != nil {
+			return fmt.Errorf("judged-doc reinsert: %w", err)
+		}
 		log.WithFields(log.Fields{
 			"churned": len(quality.relevantIdx), "mode": cfg.TombstoneMode, "target": "judged",
 		}).Printf("Generated tombstones")
-		return
+		return nil
 	}
 
-	deleted := batchDeleteDocIDRange(&cfg, client, k)
+	deleted, err := batchDeleteDocIDRange(ctx, &cfg, client, k)
+	if err != nil {
+		return fmt.Errorf("batch delete docId<%d: %w", k, err)
+	}
 	log.WithFields(log.Fields{
 		"deleted": deleted, "mode": cfg.TombstoneMode, "range": k, "tenant": tenant,
 	}).Printf("Generated tombstones")
 
 	if cfg.TombstoneMode == "delete" {
-		return
+		return nil
 	}
 	// Default ("update"): reinsert the same document range.
 	loadTrainData(ds, &cfg, 0, uint(k), 0)
+	return nil
 }
 
 // batchDeleteDocIDRange deletes all objects with docId < end, looping because the
 // server deletes at most QUERY_MAXIMUM_RESULTS (~10k) objects per call. Returns
 // the total number of objects deleted.
-func batchDeleteDocIDRange(cfg *Config, client *weaviate.Client, end int) int64 {
+func batchDeleteDocIDRange(ctx context.Context, cfg *Config, client *weaviate.Client, end int) (int64, error) {
 	where := filters.Where().
 		WithPath([]string{"docId"}).
 		WithOperator(filters.LessThan).
@@ -438,22 +500,21 @@ func batchDeleteDocIDRange(cfg *Config, client *weaviate.Client, end int) int64 
 		if cfg.Tenant != "" {
 			deleter = deleter.WithTenant(cfg.Tenant)
 		}
-		resp, err := deleter.Do(context.Background())
+		resp, err := deleter.Do(ctx)
 		if err != nil {
-			log.Fatalf("Error batch-deleting objects for tombstones: %v", err)
+			return total, fmt.Errorf("batch-deleting objects for tombstones: %w", err)
 		}
-		if resp.Results == nil || resp.Results.Successful == 0 {
-			break
+		if resp == nil || resp.Results == nil || resp.Results.Successful == 0 {
+			return total, nil
 		}
 		total += resp.Results.Successful
 	}
-	return total
 }
 
 // bm25ResultRow builds one JSON result row, reusing the ANN-compatible
 // ResultsJSONBenchmark shape and adding BM25/tombstone-specific fields plus any
 // user --labels, so runs remain ingestible by weaviate-performance-tests.
-func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID, phase string, iteration int, tombstoneRatio float64, quality *bm25Quality, retrievability float64, corpusDocs int) map[string]interface{} {
+func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID, phase string, iteration int, tombstoneRatio float64, quality *bm25Quality, qualityFailed int, retrievability float64, corpusDocs int) map[string]interface{} {
 	p99 := 0.0
 	if len(result.Percentiles) > 0 {
 		p99 = result.Percentiles[len(result.Percentiles)-1].Seconds()
@@ -504,6 +565,11 @@ func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID,
 		row["scoredQueries"] = quality.scoredQueries
 		row["qrelsFile"] = filepath.Base(quality.qrelsFile)
 		row["tokenization"] = cfg.Tokenization
+		if qualityFailed >= 0 {
+			// Failed queries shrink the recall/ndcg averaging denominator; surface
+			// the count so downstream can discount incomplete quality passes.
+			row["qualityFailedQueries"] = qualityFailed
+		}
 	}
 	if retrievability >= 0 {
 		row["tombstoneRetrievability"] = retrievability

--- a/benchmarker/cmd/bm25_benchmark.go
+++ b/benchmarker/cmd/bm25_benchmark.go
@@ -52,6 +52,14 @@ BM25 keyword-search performance under tombstone load.`,
 		ds := NewBeirDataset(cfg.CorpusFile, cfg.QueriesFile, cfg.Filter, cfg.FilterCount)
 		defer ds.Close()
 
+		// Build the quality context (qrels resolution, id mapping, 0-scored
+		// fail-fast) BEFORE the import so a qrels/split mismatch aborts immediately
+		// rather than after a potentially long corpus load.
+		var quality *bm25Quality
+		if cfg.MeasureQuality {
+			quality = buildQuality(&cfg, ds)
+		}
+
 		client := createClient(&cfg)
 
 		var importTime time.Duration
@@ -79,7 +87,7 @@ BM25 keyword-search performance under tombstone load.`,
 		}
 		log.WithFields(log.Fields{"queries": len(queries)}).Info("Loaded BM25 queries")
 
-		runBM25Queries(&cfg, client, ds, queries, importTime)
+		runBM25Queries(&cfg, client, ds, queries, importTime, quality)
 	},
 }
 
@@ -186,37 +194,71 @@ func loadBM25Data(ds *BeirDataset, cfg *Config, client *weaviate.Client) time.Du
 
 // runBM25Queries runs the phased measurement (baseline, then tombstone phases if
 // requested) and writes one labeled result row per phase to ./results/{runID}.json.
-func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queries []string, importTime time.Duration) {
+// When quality != nil, each non-concurrent phase also runs a deterministic
+// qrels-based quality pass (NDCG@k/Recall@k) and the tombstone phases run a
+// retrievability probe.
+func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queries []string, importTime time.Duration, quality *bm25Quality) {
 	runID := fmt.Sprintf("%d", time.Now().Unix())
+	corpusDocs := ds.NumTrainVectors()
 	var rows []map[string]interface{}
 
-	measure := func(phase string, iteration int, tombstoneRatio float64) {
+	// measure runs the throughput pass and (when withQuality) a separate quality
+	// pass, emitting one row. The quality pass polls until the metric stabilizes so
+	// index/replication lag on a multi-node cluster isn't read as a quality change.
+	// For tombstone phases it also records the retrievability probe (measured on the
+	// settled index). isTombstone gates the probe.
+	measure := func(phase string, iteration int, tombstoneRatio float64, withQuality, isTombstone bool) {
 		var result Results
 		if cfg.QueryDuration > 0 {
 			result = benchmarkBM25Duration(*cfg, queries)
 		} else {
 			result = benchmarkBM25(*cfg, queries)
 		}
+		retrievability := -1.0
+		if withQuality && quality != nil {
+			qr := stableQuality(*cfg, quality, 180*time.Second)
+			result.Recall = qr.Recall
+			result.NDCG = qr.NDCG
+			if isTombstone && cfg.TombstoneMode != "delete" {
+				retrievability = tombstoneRetrievability(cfg, quality, 100)
+			}
+		}
 		log.WithFields(log.Fields{
 			"phase": phase, "iteration": iteration, "tombstoneRatio": tombstoneRatio,
 			"mean": result.Mean, "qps": result.QueriesPerSecond,
-			"parallel": cfg.Parallel, "limit": cfg.Limit, "failed": result.Failed,
+			"recall": result.Recall, "ndcg": result.NDCG, "failed": result.Failed,
 		}).Infof("BM25 %s result", phase)
 		if _, err := result.WriteTextTo(os.Stdout); err != nil {
 			log.Warnf("Error writing results to stdout: %v", err)
 		}
-		rows = append(rows, bm25ResultRow(cfg, result, importTime, runID, phase, iteration, tombstoneRatio))
+		// Only attach the quality labels (benchmarkType=bm25-qrels, cutoffs, ...) to
+		// rows where quality was actually measured; the concurrent phase skips it, so
+		// its row stays a pure latency-under-churn row (no misleading recall=0 on a
+		// bm25-qrels-labeled row).
+		qualityForRow := quality
+		if !withQuality {
+			qualityForRow = nil
+		}
+		rows = append(rows, bm25ResultRow(cfg, result, importTime, runID, phase, iteration, tombstoneRatio, qualityForRow, retrievability, corpusDocs))
+	}
+
+	// In quality mode, wait for the freshly-imported corpus to be searchable before
+	// the baseline (docs findable via the competition-free probe). Combined with the
+	// metric-stability settle inside measure(), this handles both failure modes seen
+	// on a lagging multi-node cluster: docs not yet indexed, and docs indexed but the
+	// full corpus (and thus collection stats / ranking) not yet settled.
+	if quality != nil {
+		waitRetrievable(cfg, quality, 0.99, 5*time.Minute)
 	}
 
 	// Baseline (0 tombstones). Always run when there is no tombstone phase, so at
 	// least one measurement is produced.
 	if cfg.MeasureBaseline || cfg.TombstonePercentage <= 0 {
-		measure("baseline", 0, 0)
+		measure("baseline", 0, 0, true, false)
 	}
 
 	if cfg.TombstonePercentage > 0 {
-		total := ds.NumTrainVectors()
-		k := int(math.Floor(cfg.TombstonePercentage * float64(total)))
+		k := int(math.Floor(cfg.TombstonePercentage * float64(corpusDocs)))
 		if k < 1 {
 			k = 1
 		}
@@ -227,6 +269,8 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 
 		if cfg.TombstoneConcurrent {
 			// Sustain churn in the background while a single query window runs.
+			// Quality is skipped here: the index is moving, so a qrels number would
+			// be a noisy snapshot, not a stable gate value.
 			stop := make(chan struct{})
 			done := make(chan struct{})
 			go func() {
@@ -236,17 +280,25 @@ func runBM25Queries(cfg *Config, client *weaviate.Client, ds *BeirDataset, queri
 					case <-stop:
 						return
 					default:
-						generateTombstones(cfg, client, ds, k)
+						generateTombstones(cfg, client, ds, k, quality)
 					}
 				}
 			}()
-			measure("concurrent", 0, cfg.TombstonePercentage)
+			measure("concurrent", 0, cfg.TombstonePercentage, false, false)
 			close(stop)
 			<-done
 		} else {
 			for it := 1; it <= iterations; it++ {
-				generateTombstones(cfg, client, ds, k)
-				measure("tombstoned", it, cfg.TombstonePercentage*float64(it))
+				generateTombstones(cfg, client, ds, k, quality)
+				// Wait for the reinserted docs to become searchable before measuring
+				// quality: their reindex can lag on a multi-node cluster, and that
+				// transient window must not be read as a regression. A real bug (docs
+				// never recover) still surfaces — retrievability stays low and the
+				// quality drop is reported.
+				if quality != nil && cfg.TombstoneMode != "delete" {
+					waitRetrievable(cfg, quality, 0.99, 5*time.Minute)
+				}
+				measure("tombstoned", it, cfg.TombstonePercentage*float64(it), true, true)
 			}
 		}
 	}
@@ -318,23 +370,44 @@ func benchmarkBM25Duration(cfg Config, queries []string) Results {
 // (docId < k). Under multi-tenancy each tenant has its own inverted index, so it
 // churns every tenant. It never mutates the shared cfg (it passes per-tenant
 // Config copies), which keeps it safe to run concurrently with the query phase.
-func generateTombstones(cfg *Config, client *weaviate.Client, ds *BeirDataset, k int) {
+func generateTombstones(cfg *Config, client *weaviate.Client, ds *BeirDataset, k int, quality *bm25Quality) {
 	if cfg.NumTenants > 0 {
 		for i := 0; i < cfg.NumTenants; i++ {
-			tombstoneOnce(*cfg, client, ds, k, fmt.Sprintf("%d", i))
+			tombstoneOnce(*cfg, client, ds, k, fmt.Sprintf("%d", i), quality)
 		}
 		return
 	}
-	tombstoneOnce(*cfg, client, ds, k, cfg.Tenant)
+	tombstoneOnce(*cfg, client, ds, k, cfg.Tenant, quality)
 }
 
-// tombstoneOnce deletes docId < k in a single tenant (empty tenant = single-tenant
-// mode). In "update" mode it reinserts those same documents (identical UUIDs +
+// tombstoneOnce creates tombstones in a single tenant (empty tenant = single-tenant
+// mode). In "update" mode it reinserts the same documents (identical UUIDs +
 // docIds) so the corpus size holds and each old docID becomes a fresh tombstone —
 // matching an update-heavy workload. cfg is taken by value so the tenant
 // assignment stays local.
-func tombstoneOnce(cfg Config, client *weaviate.Client, ds *BeirDataset, k int, tenant string) {
+//
+// When quality measurement is active it churns the JUDGED (relevant) docs rather
+// than docId<k, so a tombstone-handling bug actually moves NDCG/Recall (on a large
+// corpus the first-k docs are otherwise disjoint from the judged set). Quality mode
+// is single-tenant, so this path never runs multi-tenant.
+func tombstoneOnce(cfg Config, client *weaviate.Client, ds *BeirDataset, k int, tenant string, quality *bm25Quality) {
 	cfg.Tenant = tenant
+
+	// Judged-doc-biased churn only applies to update mode: delete+reinsert the
+	// relevant docs so a reindex/tombstone bug shows up as a quality drop while a
+	// correct engine keeps quality flat. Delete mode falls through to the docId<k
+	// churn (it does NOT delete judged docs), so delete-mode quality does not
+	// exercise relevance churn — it just measures quality after deleting the first k
+	// (mostly non-judged) docs.
+	if quality != nil && cfg.TombstoneMode != "delete" && len(quality.relevantIdx) > 0 {
+		deleteUuidSlice(&cfg, client, quality.relevantIdx)
+		reinsertDocs(&cfg, quality.relevantDocs)
+		log.WithFields(log.Fields{
+			"churned": len(quality.relevantIdx), "mode": cfg.TombstoneMode, "target": "judged",
+		}).Printf("Generated tombstones")
+		return
+	}
+
 	deleted := batchDeleteDocIDRange(&cfg, client, k)
 	log.WithFields(log.Fields{
 		"deleted": deleted, "mode": cfg.TombstoneMode, "range": k, "tenant": tenant,
@@ -380,7 +453,7 @@ func batchDeleteDocIDRange(cfg *Config, client *weaviate.Client, end int) int64 
 // bm25ResultRow builds one JSON result row, reusing the ANN-compatible
 // ResultsJSONBenchmark shape and adding BM25/tombstone-specific fields plus any
 // user --labels, so runs remain ingestible by weaviate-performance-tests.
-func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID, phase string, iteration int, tombstoneRatio float64) map[string]interface{} {
+func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID, phase string, iteration int, tombstoneRatio float64, quality *bm25Quality, retrievability float64, corpusDocs int) map[string]interface{} {
 	p99 := 0.0
 	if len(result.Percentiles) > 0 {
 		p99 = result.Percentiles[len(result.Percentiles)-1].Seconds()
@@ -397,6 +470,8 @@ func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID,
 		RunID:            runID,
 		IterationRunID:   fmt.Sprintf("%d", iteration),
 		Dataset:          filepath.Base(cfg.CorpusFile),
+		Recall:           result.Recall,
+		NDCG:             result.NDCG,
 		Timestamp:        time.Now().Format(time.RFC3339),
 	}
 
@@ -416,8 +491,22 @@ func bm25ResultRow(cfg *Config, result Results, importTime time.Duration, runID,
 	row["queryProperties"] = cfg.QueryProperties
 	row["bm25k1"] = cfg.BM25K1
 	row["bm25b"] = cfg.BM25B
+	row["corpusDocs"] = corpusDocs
 	if cfg.Filter {
 		row["filterCount"] = cfg.FilterCount
+	}
+	if quality != nil {
+		// A discriminating label so BM25 relevance-vs-qrels recall/ndcg are never
+		// conflated with ANN agreement-vs-neighbors in Grafana or threshold configs.
+		row["benchmarkType"] = "bm25-qrels"
+		row["ndcgCutoff"] = cfg.NDCGCutoff
+		row["recallCutoff"] = cfg.RecallCutoff
+		row["scoredQueries"] = quality.scoredQueries
+		row["qrelsFile"] = filepath.Base(quality.qrelsFile)
+		row["tokenization"] = cfg.Tokenization
+	}
+	if retrievability >= 0 {
+		row["tombstoneRetrievability"] = retrievability
 	}
 	for key, value := range cfg.LabelMap {
 		row[key] = value
@@ -484,6 +573,12 @@ func initBM25Benchmark() {
 	f.IntVar(&globalConfig.TombstoneIterations, "tombstoneIterations", 1, "Number of tombstone-generation iterations (re-measured each time)")
 	f.BoolVar(&globalConfig.TombstoneConcurrent, "tombstoneConcurrent", false, "Churn tombstones in the background during the query run")
 	f.BoolVar(&globalConfig.MeasureBaseline, "measureBaseline", true, "Run a 0-tombstone baseline before the tombstone phase")
+
+	// Quality measurement (qrels-based regression gate)
+	f.BoolVar(&globalConfig.MeasureQuality, "measureQuality", false, "Measure NDCG@k / Recall@k vs BEIR qrels (fills recall/ndcg)")
+	f.StringVar(&globalConfig.QrelsFile, "qrels", "", "Path to BEIR qrels TSV; if empty, auto-detect <corpusdir>/qrels/{test,dev}.tsv")
+	f.IntVar(&globalConfig.NDCGCutoff, "ndcgCutoff", 10, "NDCG cutoff written to the ndcg field")
+	f.IntVar(&globalConfig.RecallCutoff, "recallCutoff", 100, "Recall cutoff written to the recall field")
 
 	// Import & topology
 	f.IntVarP(&globalConfig.BatchSize, "batchSize", "b", 1000, "Batch size for import")

--- a/benchmarker/cmd/bm25_benchmark_test.go
+++ b/benchmarker/cmd/bm25_benchmark_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// validBM25Config returns a minimal Config that passes validateBM25, for
+// mutation in table tests.
+func validBM25Config() Config {
+	return Config{
+		Mode:          "bm25-benchmark",
+		API:           "grpc",
+		CorpusFile:    "corpus.jsonl",
+		QueriesFile:   "queries.jsonl",
+		SearchType:    "bm25",
+		TombstoneMode: "update",
+		Parallel:      1,
+	}
+}
+
+func TestParseLimitValues(t *testing.T) {
+	got, err := parseLimitValues("10,100,1000,10000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []int{10, 100, 1000, 10000}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+
+	got, err = parseLimitValues(" 10, 100 ")
+	if err != nil {
+		t.Fatalf("values with spaces must parse, got error: %v", err)
+	}
+	if len(got) != 2 || got[0] != 10 || got[1] != 100 {
+		t.Fatalf("got %v, want [10 100]", got)
+	}
+
+	if _, err = parseLimitValues("10,abc"); err == nil {
+		t.Fatal("expected error for non-integer value")
+	} else if !strings.Contains(err.Error(), "limitArray") {
+		t.Errorf("error should name the limitArray flag, got: %v", err)
+	}
+}
+
+func TestValidateBM25LimitArray(t *testing.T) {
+	tests := []struct {
+		name                string
+		limitArray          string
+		tombstonePercentage float64
+		wantErr             string
+	}{
+		{name: "no sweep", limitArray: "", wantErr: ""},
+		{name: "valid sweep", limitArray: "10,100,1000,10000", wantErr: ""},
+		{name: "tombstones without sweep stay valid", limitArray: "", tombstonePercentage: 0.3, wantErr: ""},
+		{name: "invalid csv", limitArray: "10,x", wantErr: "limitArray"},
+		{name: "non-positive value", limitArray: "10,0", wantErr: "at least 1"},
+		{name: "combined with tombstones", limitArray: "10,100", tombstonePercentage: 0.3, wantErr: "cannot be combined"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBM25Config()
+			cfg.LimitArray = tt.limitArray
+			cfg.TombstonePercentage = tt.tombstonePercentage
+
+			err := cfg.validateBM25()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/benchmarker/cmd/bm25_quality.go
+++ b/benchmarker/cmd/bm25_quality.go
@@ -12,6 +12,7 @@ import (
 	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -140,7 +141,9 @@ func measureBM25Quality(cfg Config, q *bm25Quality) Results {
 }
 
 // dialGrpcConn opens a gRPC connection to the configured origin (matches the
-// transport setup used by benchmark()/loadTrainData).
+// transport setup used by benchmark()/loadTrainData). WithBlock makes the 30s
+// timeout actually bound connection establishment, so callers see dial failures
+// here instead of on their first RPC.
 func dialGrpcConn(cfg *Config) (*grpc.ClientConn, error) {
 	opt := grpc.WithInsecure()
 	if cfg.HttpScheme == "https" {
@@ -149,35 +152,47 @@ func dialGrpcConn(cfg *Config) (*grpc.ClientConn, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	return grpc.DialContext(ctx, cfg.Origin, opt)
+	return grpc.DialContext(ctx, cfg.Origin, opt, grpc.WithBlock())
+}
+
+// grpcAuthCtx attaches the Authorization: Bearer metadata when --httpAuth
+// (HTTP_AUTH) is configured, matching processQueueGrpc/writeChunk — raw-gRPC
+// helpers must not silently drop auth that the rest of the tool sends.
+func grpcAuthCtx(ctx context.Context, cfg *Config) context.Context {
+	if cfg.HttpAuth == "" {
+		return ctx
+	}
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", cfg.HttpAuth))
+	return metadata.NewOutgoingContext(ctx, md)
 }
 
 // reinsertDocs writes a specific, possibly non-contiguous set of documents back at
 // their exact docIndex (same UUID + docId), used by judged-doc-biased tombstone
 // churn where the target set is scattered across the corpus.
-func reinsertDocs(cfg *Config, docs map[int]beirCorpusDoc) {
+func reinsertDocs(ctx context.Context, cfg *Config, docs map[int]beirCorpusDoc) error {
 	if len(docs) == 0 {
-		return
+		return nil
 	}
 	conn, err := dialGrpcConn(cfg)
 	if err != nil {
-		log.Fatalf("reinsertDocs: grpc dial: %v", err)
+		return fmt.Errorf("grpc dial: %w", err)
 	}
 	defer conn.Close()
 	client := weaviategrpc.NewWeaviateClient(conn)
 
 	const chunk = 500
 	objects := make([]*weaviategrpc.BatchObject, 0, chunk)
-	flush := func() {
+	flush := func() error {
 		if len(objects) == 0 {
-			return
+			return nil
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+		batchCtx, cancel := context.WithTimeout(ctx, time.Second*300)
 		defer cancel()
-		if _, err := client.BatchObjects(ctx, &weaviategrpc.BatchObjectsRequest{Objects: objects}); err != nil {
-			log.Fatalf("reinsertDocs: batch: %v", err)
+		if _, err := client.BatchObjects(grpcAuthCtx(batchCtx, cfg), &weaviategrpc.BatchObjectsRequest{Objects: objects}); err != nil {
+			return fmt.Errorf("batch: %w", err)
 		}
 		objects = objects[:0]
+		return nil
 	}
 
 	for idx, doc := range docs {
@@ -187,7 +202,7 @@ func reinsertDocs(cfg *Config, docs map[int]beirCorpusDoc) {
 			"docId": float64(idx + cfg.Offset),
 		})
 		if err != nil {
-			log.Fatalf("reinsertDocs: struct: %v", err)
+			return fmt.Errorf("struct: %w", err)
 		}
 		obj := &weaviategrpc.BatchObject{
 			Uuid:       uuidFromInt(idx + cfg.Offset),
@@ -199,10 +214,12 @@ func reinsertDocs(cfg *Config, docs map[int]beirCorpusDoc) {
 		}
 		objects = append(objects, obj)
 		if len(objects) >= chunk {
-			flush()
+			if err := flush(); err != nil {
+				return err
+			}
 		}
 	}
-	flush()
+	return flush()
 }
 
 // tombstoneRetrievability probes whether reinserted (relevant) documents are still
@@ -255,7 +272,7 @@ func tombstoneRetrievability(cfg *Config, q *bm25Quality, sampleSize int) float6
 			req.Tenant = cfg.Tenant
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		reply, err := client.Search(ctx, req)
+		reply, err := client.Search(grpcAuthCtx(ctx, cfg), req)
 		cancel()
 		if err != nil {
 			log.Debugf("retrievability probe query error (soft): %v", err)
@@ -285,8 +302,10 @@ func stableQuality(cfg Config, q *bm25Quality, timeout time.Duration) Results {
 
 // settleMetric polls `poll` every `interval` until neither NDCG nor Recall has
 // improved by more than `epsilon` for `patience` consecutive polls, then returns
-// the per-metric maxima seen. Factored out of stableQuality so the settle logic is
-// unit-testable with a scripted poll sequence.
+// the per-metric maxima seen. Successful/Failed/Total reflect the LAST poll, so
+// callers can tell how complete the settled measurement was (a shrunken averaging
+// denominator must not pass silently). Factored out of stableQuality so the settle
+// logic is unit-testable with a scripted poll sequence.
 func settleMetric(poll func() Results, interval time.Duration, patience int, epsilon float64, timeout time.Duration) Results {
 	best := poll()
 	stale := 0
@@ -305,6 +324,9 @@ func settleMetric(poll func() Results, interval time.Duration, patience int, eps
 		if cur.Recall > best.Recall {
 			best.Recall = cur.Recall
 		}
+		best.Successful = cur.Successful
+		best.Failed = cur.Failed
+		best.Total = cur.Total
 		if improved {
 			stale = 0
 			log.WithFields(log.Fields{"ndcg": cur.NDCG, "recall": cur.Recall}).Debug("quality still improving; index settling")

--- a/benchmarker/cmd/bm25_quality.go
+++ b/benchmarker/cmd/bm25_quality.go
@@ -1,0 +1,349 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// bm25Quality holds everything the qrels-based quality pass, judged-doc-biased
+// churn, and retrievability probe need. It is built once (buildQuality) when
+// --measureQuality is set.
+type bm25Quality struct {
+	queries       []beirQuery           // all queries (with ids)
+	relevant      []map[int]int         // per-query-index relevant map (docIndex -> grade, grade>0); nil if query unscored
+	scoredQueries int                   // queries with >=1 relevant doc mapped
+	qrelsFile     string                // resolved qrels path
+	relevantIdx   []int                 // sorted union of relevant docIndices (churn target for biased churn)
+	relevantDocs  map[int]beirCorpusDoc // content for targeted reinsert during biased churn
+	depth         int                   // retrieval depth for the quality pass = max(ndcgCutoff, recallCutoff)
+}
+
+// buildQuality resolves qrels, maps relevance judgments onto document indices, and
+// fails fast when nothing is scorable (an id/split mismatch would otherwise yield a
+// silent recall=0 that reads as a passing gate).
+func buildQuality(cfg *Config, ds *BeirDataset) *bm25Quality {
+	qrelsPath := resolveQrelsPath(cfg.CorpusFile, cfg.QrelsFile)
+	if qrelsPath == "" {
+		fatal(fmt.Errorf("--measureQuality requires qrels; pass --qrels or place qrels/test.tsv (or dev.tsv) next to the corpus"))
+	}
+	qrels, err := LoadQrels(qrelsPath)
+	if err != nil {
+		fatal(fmt.Errorf("loading qrels %s: %w", qrelsPath, err))
+	}
+	queries := ds.LoadQueriesWithIDs()
+
+	judged := make(map[string]bool)
+	for _, docs := range qrels {
+		for did, g := range docs {
+			if g > 0 {
+				judged[did] = true
+			}
+		}
+	}
+	idToIndex, byIndex, err := ds.scanJudged(judged)
+	if err != nil {
+		fatal(fmt.Errorf("scanning corpus for judged docs: %w", err))
+	}
+
+	relevant := make([]map[int]int, len(queries))
+	relevantIdxSet := make(map[int]bool)
+	scored := 0
+	for i, q := range queries {
+		grades := qrels[q.ID]
+		if grades == nil {
+			continue
+		}
+		rm := make(map[int]int)
+		for did, g := range grades {
+			if g <= 0 {
+				continue
+			}
+			if idx, ok := idToIndex[did]; ok {
+				rm[idx] = g
+				relevantIdxSet[idx] = true
+			}
+		}
+		if len(rm) > 0 {
+			relevant[i] = rm
+			scored++
+		}
+	}
+	if scored == 0 {
+		fatal(fmt.Errorf("--measureQuality: 0 scored queries against %s (qrels/corpus id mismatch or wrong split); queries=%d", qrelsPath, len(queries)))
+	}
+
+	relevantIdx := make([]int, 0, len(relevantIdxSet))
+	relevantDocs := make(map[int]beirCorpusDoc, len(relevantIdxSet))
+	for idx := range relevantIdxSet {
+		relevantIdx = append(relevantIdx, idx)
+		if doc, ok := byIndex[idx]; ok {
+			relevantDocs[idx] = doc
+		}
+	}
+	sort.Ints(relevantIdx)
+
+	depth := cfg.NDCGCutoff
+	if cfg.RecallCutoff > depth {
+		depth = cfg.RecallCutoff
+	}
+
+	log.WithFields(log.Fields{
+		"scored": scored, "total": len(queries), "relevantDocs": len(relevantIdx),
+		"qrels": qrelsPath, "ndcgCutoff": cfg.NDCGCutoff, "recallCutoff": cfg.RecallCutoff,
+	}).Info("Quality measurement enabled")
+
+	return &bm25Quality{
+		queries: queries, relevant: relevant, scoredQueries: scored,
+		qrelsFile: qrelsPath, relevantIdx: relevantIdx, relevantDocs: relevantDocs, depth: depth,
+	}
+}
+
+// measureBM25Quality runs a deterministic pass — each scored query once, retrieval
+// depth = q.depth, unfiltered/single-tenant — and returns Results whose Recall =
+// Recall@recallCutoff and NDCG = NDCG@ndcgCutoff (graded, vs qrels). Latency here
+// is not used for the perf axis.
+func measureBM25Quality(cfg Config, q *bm25Quality) Results {
+	cfg.Limit = q.depth
+	cfg.Filter = false
+
+	type scoredQuery struct {
+		text string
+		rel  map[int]int
+	}
+	scored := make([]scoredQuery, 0, q.scoredQueries)
+	for i, query := range q.queries {
+		if q.relevant[i] != nil {
+			scored = append(scored, scoredQuery{query.Text, q.relevant[i]})
+		}
+	}
+	cfg.Queries = len(scored)
+
+	i := 0
+	return benchmark(cfg, func(className string) QueryWithNeighbors {
+		s := scored[i]
+		i++
+		return QueryWithNeighbors{
+			Query:     bm25QueryGrpc(&cfg, s.text, "", -1),
+			Relevance: s.rel,
+		}
+	})
+}
+
+// dialGrpcConn opens a gRPC connection to the configured origin (matches the
+// transport setup used by benchmark()/loadTrainData).
+func dialGrpcConn(cfg *Config) (*grpc.ClientConn, error) {
+	opt := grpc.WithInsecure()
+	if cfg.HttpScheme == "https" {
+		creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
+		opt = grpc.WithTransportCredentials(creds)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return grpc.DialContext(ctx, cfg.Origin, opt)
+}
+
+// reinsertDocs writes a specific, possibly non-contiguous set of documents back at
+// their exact docIndex (same UUID + docId), used by judged-doc-biased tombstone
+// churn where the target set is scattered across the corpus.
+func reinsertDocs(cfg *Config, docs map[int]beirCorpusDoc) {
+	if len(docs) == 0 {
+		return
+	}
+	conn, err := dialGrpcConn(cfg)
+	if err != nil {
+		log.Fatalf("reinsertDocs: grpc dial: %v", err)
+	}
+	defer conn.Close()
+	client := weaviategrpc.NewWeaviateClient(conn)
+
+	const chunk = 500
+	objects := make([]*weaviategrpc.BatchObject, 0, chunk)
+	flush := func() {
+		if len(objects) == 0 {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
+		defer cancel()
+		if _, err := client.BatchObjects(ctx, &weaviategrpc.BatchObjectsRequest{Objects: objects}); err != nil {
+			log.Fatalf("reinsertDocs: batch: %v", err)
+		}
+		objects = objects[:0]
+	}
+
+	for idx, doc := range docs {
+		nonRef, err := structpb.NewStruct(map[string]interface{}{
+			"text":  doc.Text,
+			"title": doc.Title,
+			"docId": float64(idx + cfg.Offset),
+		})
+		if err != nil {
+			log.Fatalf("reinsertDocs: struct: %v", err)
+		}
+		obj := &weaviategrpc.BatchObject{
+			Uuid:       uuidFromInt(idx + cfg.Offset),
+			Collection: cfg.ClassName,
+			Properties: &weaviategrpc.BatchObject_Properties{NonRefProperties: nonRef},
+		}
+		if cfg.Tenant != "" {
+			obj.Tenant = cfg.Tenant
+		}
+		objects = append(objects, obj)
+		if len(objects) >= chunk {
+			flush()
+		}
+	}
+	flush()
+}
+
+// tombstoneRetrievability probes whether reinserted (relevant) documents are still
+// findable via BM25 after churn. For a sample of docs it issues a keyword query
+// built from the doc's own text and checks the doc is returned. A just-reinserted
+// doc MUST be findable; a fraction < 1.0 signals an inverted-index tombstone
+// mishandling. This is a within-run invariant needing no baseline.
+func tombstoneRetrievability(cfg *Config, q *bm25Quality, sampleSize int) float64 {
+	sample := q.relevantIdx
+	if len(sample) == 0 {
+		return 1.0
+	}
+	if len(sample) > sampleSize {
+		sample = sample[:sampleSize]
+	}
+
+	conn, err := dialGrpcConn(cfg)
+	if err != nil {
+		log.Warnf("retrievability probe: grpc dial: %v", err)
+		return -1
+	}
+	defer conn.Close()
+	client := weaviategrpc.NewWeaviateClient(conn)
+
+	found := 0
+	for _, idx := range sample {
+		doc := q.relevantDocs[idx]
+		queryText := firstTokens(doc.Title+" "+doc.Text, 12)
+		if queryText == "" {
+			found++ // nothing to probe with; don't penalize
+			continue
+		}
+		// Competition-free probe: a BM25 query over the doc's own terms restricted
+		// to docId == idx. If the doc's postings survived the delete+reinsert it is
+		// a BM25 candidate and comes back (Limit 1); if the tombstone orphaned its
+		// postings it isn't a candidate and nothing returns — no ranking against
+		// other docs, so common query terms can't cause a false negative.
+		req := &weaviategrpc.SearchRequest{
+			Collection: cfg.ClassName,
+			Limit:      1,
+			Bm25Search: &weaviategrpc.BM25{Query: queryText, Properties: []string{"text", "title"}},
+			Filters: &weaviategrpc.Filters{
+				On:        []string{"docId"},
+				Operator:  weaviategrpc.Filters_OPERATOR_EQUAL,
+				TestValue: &weaviategrpc.Filters_ValueInt{ValueInt: int64(idx + cfg.Offset)},
+			},
+			Metadata: &weaviategrpc.MetadataRequest{Uuid: true},
+		}
+		if cfg.Tenant != "" {
+			req.Tenant = cfg.Tenant
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		reply, err := client.Search(ctx, req)
+		cancel()
+		if err != nil {
+			log.Debugf("retrievability probe query error (soft): %v", err)
+			continue
+		}
+		if len(reply.GetResults()) > 0 {
+			found++
+		}
+	}
+	return float64(found) / float64(len(sample))
+}
+
+// stableQuality runs the quality pass repeatedly until the metric stops improving,
+// then returns the best (settled) Results. The qrels metric is deterministic for a
+// settled index; while the inverted index is still building (import/reinsert lag on
+// a multi-node cluster) NDCG/Recall climb — often in steps — toward the true value,
+// so we wait until they stop climbing rather than until two samples merely agree
+// (which a transient mid-indexing plateau would satisfy prematurely). The patience
+// counter resets on any climb, so a stepwise settle (e.g. 0.17 → 0.23) is handled.
+// A genuine regression (results never recover) still surfaces: the returned value
+// stays low.
+func stableQuality(cfg Config, q *bm25Quality, timeout time.Duration) Results {
+	// patience×interval = 60s of no improvement ⇒ settled; generous enough to ride
+	// out the stepwise index-build plateaus seen on a lagging multi-node cluster.
+	return settleMetric(func() Results { return measureBM25Quality(cfg, q) }, 12*time.Second, 5, 0.003, timeout)
+}
+
+// settleMetric polls `poll` every `interval` until neither NDCG nor Recall has
+// improved by more than `epsilon` for `patience` consecutive polls, then returns
+// the per-metric maxima seen. Factored out of stableQuality so the settle logic is
+// unit-testable with a scripted poll sequence.
+func settleMetric(poll func() Results, interval time.Duration, patience int, epsilon float64, timeout time.Duration) Results {
+	best := poll()
+	stale := 0
+	start := time.Now()
+	for time.Since(start) < timeout {
+		time.Sleep(interval)
+		cur := poll()
+		// Track each metric's running max independently: the index builds
+		// bottom-up, so NDCG@10 typically saturates before Recall@100. Advancing
+		// `best` only on an NDCG rise would freeze `best.Recall` at an understated
+		// value while a still-climbing Recall looks like perpetual improvement.
+		improved := cur.NDCG > best.NDCG+epsilon || cur.Recall > best.Recall+epsilon
+		if cur.NDCG > best.NDCG {
+			best.NDCG = cur.NDCG
+		}
+		if cur.Recall > best.Recall {
+			best.Recall = cur.Recall
+		}
+		if improved {
+			stale = 0
+			log.WithFields(log.Fields{"ndcg": cur.NDCG, "recall": cur.Recall}).Debug("quality still improving; index settling")
+			continue
+		}
+		if stale++; stale >= patience {
+			return best
+		}
+	}
+	log.Warnf("quality metric did not settle within %s (ndcg=%.4f) — index still building or a real regression", timeout, best.NDCG)
+	return best
+}
+
+// waitRetrievable polls the retrievability probe until reinserted docs are
+// searchable again (>= threshold) or the timeout elapses, then returns the final
+// value. Used after a delete+reinsert to wait out indexing/replication lag before
+// measuring quality, so a transient window isn't read as a regression. A genuine
+// tombstone bug (docs never recover) surfaces: the value stays low and is logged.
+func waitRetrievable(cfg *Config, q *bm25Quality, threshold float64, timeout time.Duration) float64 {
+	start := time.Now()
+	for {
+		r := tombstoneRetrievability(cfg, q, 50)
+		if r < 0 || r >= threshold {
+			return r
+		}
+		if time.Since(start) > timeout {
+			log.Warnf("retrievability %.2f still below %.2f after %s — possible tombstone regression or very slow indexing", r, threshold, timeout)
+			return r
+		}
+		log.Debugf("waiting for reinserted docs to become searchable: retrievability %.2f", r)
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// firstTokens returns the first n whitespace-separated tokens of s.
+func firstTokens(s string, n int) string {
+	fields := strings.Fields(s)
+	if len(fields) > n {
+		fields = fields[:n]
+	}
+	return strings.Join(fields, " ")
+}

--- a/benchmarker/cmd/bm25_quality_test.go
+++ b/benchmarker/cmd/bm25_quality_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSettleMetric verifies the settle state machine returns the per-metric maxima
+// and, crucially, does not freeze Recall when NDCG saturates first (the P0 bug).
+func TestSettleMetric(t *testing.T) {
+	// NDCG plateaus at 0.30 by poll 2 while Recall keeps climbing to 0.80.
+	seq := []Results{
+		{NDCG: 0.10, Recall: 0.20},
+		{NDCG: 0.30, Recall: 0.40},
+		{NDCG: 0.30, Recall: 0.55}, // NDCG saturated, recall improving
+		{NDCG: 0.30, Recall: 0.70}, // recall improving
+		{NDCG: 0.30, Recall: 0.80}, // recall improving
+		{NDCG: 0.30, Recall: 0.80}, // stale 1
+		{NDCG: 0.30, Recall: 0.80}, // stale 2
+		{NDCG: 0.30, Recall: 0.80}, // stale 3 -> settled
+		{NDCG: 0.30, Recall: 0.80},
+	}
+	i := 0
+	poll := func() Results {
+		r := seq[i]
+		if i < len(seq)-1 {
+			i++
+		}
+		return r
+	}
+	got := settleMetric(poll, time.Millisecond, 3, 0.003, 10*time.Second)
+	if got.NDCG != 0.30 {
+		t.Errorf("settled NDCG = %.3f, want 0.30", got.NDCG)
+	}
+	if got.Recall != 0.80 {
+		t.Errorf("settled Recall = %.3f, want 0.80 (must not freeze when NDCG saturates first)", got.Recall)
+	}
+}
+
+func TestSettleMetricStableImmediately(t *testing.T) {
+	// A settled index returns identical polls; should settle after `patience` polls.
+	poll := func() Results { return Results{NDCG: 0.42, Recall: 0.63} }
+	got := settleMetric(poll, time.Millisecond, 3, 0.003, 10*time.Second)
+	if got.NDCG != 0.42 || got.Recall != 0.63 {
+		t.Errorf("got NDCG=%.3f Recall=%.3f, want 0.42/0.63", got.NDCG, got.Recall)
+	}
+}

--- a/benchmarker/cmd/bm25_query.go
+++ b/benchmarker/cmd/bm25_query.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// queryPropertiesList parses the comma-separated --queryProperties flag into the
+// set of properties a BM25 query scores against. Defaults to ["text"].
+func (cfg *Config) queryPropertiesList() []string {
+	parts := strings.Split(cfg.QueryProperties, ",")
+	props := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			props = append(props, t)
+		}
+	}
+	if len(props) == 0 {
+		return []string{"text"}
+	}
+	return props
+}
+
+// bm25QueryGrpc builds a marshalled gRPC SearchRequest for a BM25 keyword query.
+// It mirrors nearVectorQueryGrpc:
+//   - Metadata requests the object UUID (required — processQueueGrpc decodes each
+//     result's UUID back into an int and uuid.Parse("") would panic).
+//   - When BM25Operator is "and"/"or", the corresponding SearchOperatorOptions is
+//     set (with MinimumOrTokensMatch for the OR case); otherwise it is left nil so
+//     the server default applies.
+//   - filter >= 0 adds an equality filter on the "category" property, enabling
+//     filtered BM25 runs of controllable selectivity.
+func bm25QueryGrpc(cfg *Config, query, tenant string, filter int) []byte {
+	metadata := &weaviategrpc.MetadataRequest{
+		Uuid: true,
+	}
+
+	bm25 := &weaviategrpc.BM25{
+		Query:      query,
+		Properties: cfg.queryPropertiesList(),
+	}
+
+	switch cfg.BM25Operator {
+	case "and":
+		bm25.SearchOperator = &weaviategrpc.SearchOperatorOptions{
+			Operator: weaviategrpc.SearchOperatorOptions_OPERATOR_AND,
+		}
+	case "or":
+		op := &weaviategrpc.SearchOperatorOptions{
+			Operator: weaviategrpc.SearchOperatorOptions_OPERATOR_OR,
+		}
+		if cfg.MinOrTokens > 0 {
+			minTokens := int32(cfg.MinOrTokens)
+			op.MinimumOrTokensMatch = &minTokens
+		}
+		bm25.SearchOperator = op
+	}
+
+	searchRequest := &weaviategrpc.SearchRequest{
+		Collection: cfg.ClassName,
+		Limit:      uint32(cfg.Limit),
+		Bm25Search: bm25,
+		Metadata:   metadata,
+	}
+
+	if tenant != "" {
+		searchRequest.Tenant = tenant
+	}
+
+	if filter >= 0 {
+		searchRequest.Filters = &weaviategrpc.Filters{
+			TestValue: &weaviategrpc.Filters_ValueText{
+				ValueText: strconv.Itoa(filter),
+			},
+			On:       []string{"category"},
+			Operator: weaviategrpc.Filters_OPERATOR_EQUAL,
+		}
+	}
+
+	data, err := proto.Marshal(searchRequest)
+	if err != nil {
+		fmt.Printf("grpc marshal err: %v\n", err)
+	}
+
+	return data
+}
+
+// Hybrid (BM25 + vector) seam for a future version. The gRPC message already
+// exists as weaviategrpc.Hybrid{Query, Properties, Vector/Vectors, Alpha,
+// FusionType, NearVector, Bm25SearchOperator}. To add hybrid benchmarking:
+//   1. Implement hybridQueryGrpc setting SearchRequest.HybridSearch (analogous to
+//      the Bm25Search wiring above).
+//   2. Add a "hybrid" branch to the query selector in benchmarkBM25.
+//   3. Give each imported document a vector (Batch.Vectors) and a vector index in
+//      createBM25Schema — for perf-only, a deterministic randomVector suffices.
+// The BEIR loader, worker-pool harness, and results output are all unchanged.

--- a/benchmarker/cmd/bm25_query.go
+++ b/benchmarker/cmd/bm25_query.go
@@ -29,6 +29,7 @@ func (cfg *Config) queryPropertiesList() []string {
 // It mirrors nearVectorQueryGrpc:
 //   - Metadata requests the object UUID (required — processQueueGrpc decodes each
 //     result's UUID back into an int and uuid.Parse("") would panic).
+//   - Properties are explicitly not returned (empty PropertiesRequest).
 //   - When BM25Operator is "and"/"or", the corresponding SearchOperatorOptions is
 //     set (with MinimumOrTokensMatch for the OR case); otherwise it is left nil so
 //     the server default applies.
@@ -65,6 +66,13 @@ func bm25QueryGrpc(cfg *Config, query, tenant string, filter int) []byte {
 		Limit:      uint32(cfg.Limit),
 		Bm25Search: bm25,
 		Metadata:   metadata,
+		// An absent Properties field makes the server return every non-ref
+		// property — full documents, which at high limits exceed the gRPC
+		// client's 4MB receive cap (~10MB at limit 10000 on fiqa) and would
+		// make the timed phase measure payload serialization rather than
+		// search. The harness only decodes UUIDs, so request no properties:
+		// an explicitly empty PropertiesRequest.
+		Properties: &weaviategrpc.PropertiesRequest{},
 	}
 
 	if tenant != "" {

--- a/benchmarker/cmd/bm25_query_test.go
+++ b/benchmarker/cmd/bm25_query_test.go
@@ -97,4 +97,14 @@ func TestBM25QueryGrpc_Defaults(t *testing.T) {
 	if srNoOp.Bm25Search.SearchOperator != nil {
 		t.Errorf("expected nil SearchOperator when BM25Operator unset, got %v", srNoOp.Bm25Search.SearchOperator)
 	}
+
+	// Return properties must be explicitly suppressed: an absent Properties
+	// field makes the server return full documents, which at high limits
+	// exceed the gRPC client's receive cap.
+	if sr.Properties == nil {
+		t.Fatal("Properties must be set (empty) to suppress returned properties")
+	}
+	if sr.Properties.ReturnAllNonrefProperties || len(sr.Properties.NonRefProperties) > 0 {
+		t.Errorf("expected empty PropertiesRequest, got %v", sr.Properties)
+	}
 }

--- a/benchmarker/cmd/bm25_query_test.go
+++ b/benchmarker/cmd/bm25_query_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"testing"
+
+	weaviategrpc "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func unmarshalSearchRequest(t *testing.T, data []byte) *weaviategrpc.SearchRequest {
+	t.Helper()
+	var sr weaviategrpc.SearchRequest
+	if err := proto.Unmarshal(data, &sr); err != nil {
+		t.Fatalf("unmarshal SearchRequest: %v", err)
+	}
+	return &sr
+}
+
+func TestBM25QueryGrpc_OrOperatorAndProperties(t *testing.T) {
+	cfg := &Config{
+		ClassName:       "Bm25Bench",
+		Limit:           10,
+		QueryProperties: "text,title",
+		BM25Operator:    "or",
+		MinOrTokens:     2,
+	}
+
+	sr := unmarshalSearchRequest(t, bm25QueryGrpc(cfg, "alpha beta", "", -1))
+
+	if sr.Collection != "Bm25Bench" {
+		t.Errorf("collection = %q, want Bm25Bench", sr.Collection)
+	}
+	if sr.Limit != 10 {
+		t.Errorf("limit = %d, want 10", sr.Limit)
+	}
+	if sr.Metadata == nil || !sr.Metadata.Uuid {
+		t.Error("metadata.uuid must be true (else result-id decode panics)")
+	}
+	if sr.Bm25Search == nil {
+		t.Fatal("bm25Search is nil")
+	}
+	if sr.Bm25Search.Query != "alpha beta" {
+		t.Errorf("query = %q, want 'alpha beta'", sr.Bm25Search.Query)
+	}
+	if got := sr.Bm25Search.Properties; len(got) != 2 || got[0] != "text" || got[1] != "title" {
+		t.Errorf("properties = %v, want [text title]", got)
+	}
+	op := sr.Bm25Search.SearchOperator
+	if op == nil || op.Operator != weaviategrpc.SearchOperatorOptions_OPERATOR_OR {
+		t.Fatalf("search operator = %v, want OR", op)
+	}
+	if op.MinimumOrTokensMatch == nil || *op.MinimumOrTokensMatch != 2 {
+		t.Errorf("minimumOrTokensMatch = %v, want 2", op.MinimumOrTokensMatch)
+	}
+	if sr.Filters != nil {
+		t.Errorf("filters must be nil when filter < 0, got %v", sr.Filters)
+	}
+}
+
+func TestBM25QueryGrpc_FilterAndTenant(t *testing.T) {
+	cfg := &Config{ClassName: "C", Limit: 5, QueryProperties: "text"}
+	sr := unmarshalSearchRequest(t, bm25QueryGrpc(cfg, "gamma", "tenantA", 3))
+
+	if sr.Tenant != "tenantA" {
+		t.Errorf("tenant = %q, want tenantA", sr.Tenant)
+	}
+	if sr.Filters == nil {
+		t.Fatal("filters nil, want category==3")
+	}
+	if sr.Filters.Operator != weaviategrpc.Filters_OPERATOR_EQUAL {
+		t.Errorf("filter operator = %v, want EQUAL", sr.Filters.Operator)
+	}
+	if len(sr.Filters.On) != 1 || sr.Filters.On[0] != "category" {
+		t.Errorf("filter on = %v, want [category]", sr.Filters.On)
+	}
+	vt, ok := sr.Filters.TestValue.(*weaviategrpc.Filters_ValueText)
+	if !ok || vt.ValueText != "3" {
+		t.Errorf("filter value = %v, want ValueText 3", sr.Filters.TestValue)
+	}
+}
+
+func TestBM25QueryGrpc_Defaults(t *testing.T) {
+	// Empty QueryProperties defaults to ["text"]; AND operator; no min-tokens.
+	cfg := &Config{ClassName: "C", Limit: 5, BM25Operator: "and"}
+	sr := unmarshalSearchRequest(t, bm25QueryGrpc(cfg, "q", "", -1))
+	if got := sr.Bm25Search.Properties; len(got) != 1 || got[0] != "text" {
+		t.Errorf("default properties = %v, want [text]", got)
+	}
+	if sr.Bm25Search.SearchOperator == nil ||
+		sr.Bm25Search.SearchOperator.Operator != weaviategrpc.SearchOperatorOptions_OPERATOR_AND {
+		t.Error("expected AND operator")
+	}
+
+	// No operator specified → SearchOperator left nil (server default applies).
+	cfgNoOp := &Config{ClassName: "C", Limit: 5}
+	srNoOp := unmarshalSearchRequest(t, bm25QueryGrpc(cfgNoOp, "q", "", -1))
+	if srNoOp.Bm25Search.SearchOperator != nil {
+		t.Errorf("expected nil SearchOperator when BM25Operator unset, got %v", srNoOp.Bm25Search.SearchOperator)
+	}
+}

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -93,6 +93,7 @@ type Config struct {
 	BM25B           float64
 	Tokenization    string
 	FilterCount     int
+	LimitArray      string
 
 	// BM25 tombstone generation (slow-path reproduction)
 	TombstonePercentage float64
@@ -264,6 +265,24 @@ func (c Config) validateBM25() error {
 
 	if c.Parallel < 1 {
 		return errors.Errorf("parallel must be at least 1")
+	}
+
+	if c.LimitArray != "" {
+		limits, err := parseLimitValues(c.LimitArray)
+		if err != nil {
+			return err
+		}
+		for _, limit := range limits {
+			if limit < 1 {
+				return errors.Errorf("--limitArray values must be at least 1, got %d", limit)
+			}
+		}
+		if c.TombstonePercentage > 0 {
+			// One sweep dimension per invocation: mixing swept limits with churn
+			// phases would duplicate values in both the limit and tombstoneRatio
+			// columns, and downstream comparisons key rows on exactly one of them.
+			return errors.Errorf("--limitArray cannot be combined with --tombstonePercentage; run the limit sweep and the tombstone sweep as separate invocations")
+		}
 	}
 
 	if c.MeasureQuality {

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -100,6 +100,12 @@ type Config struct {
 	TombstoneIterations int
 	TombstoneConcurrent bool
 	MeasureBaseline     bool
+
+	// BM25 quality measurement (qrels-based regression gate)
+	MeasureQuality bool
+	QrelsFile      string
+	NDCGCutoff     int
+	RecallCutoff   int
 }
 
 func (c *Config) Validate() error {
@@ -248,6 +254,21 @@ func (c Config) validateBM25() error {
 
 	if c.Parallel < 1 {
 		return errors.Errorf("parallel must be at least 1")
+	}
+
+	if c.MeasureQuality {
+		if c.CorpusFile == "" {
+			return errors.Errorf("--measureQuality requires --corpus (needed to map qrels doc-ids to document indices, even with --query)")
+		}
+		if c.Filter {
+			return errors.Errorf("--measureQuality is incompatible with --filter (a category filter misaligns results with corpus-wide qrels)")
+		}
+		if c.NumTenants > 0 {
+			return errors.Errorf("--measureQuality requires single-tenant (--numTenants 0)")
+		}
+		if c.NDCGCutoff < 1 || c.RecallCutoff < 1 {
+			return errors.Errorf("--ndcgCutoff and --recallCutoff must be at least 1")
+		}
 	}
 
 	return nil

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -82,6 +82,24 @@ type Config struct {
 	MaxPostingSizeKB         int
 	Replicas                 int
 	RngFactor                float64
+
+	// BM25 benchmark
+	CorpusFile      string
+	SearchType      string
+	QueryProperties string
+	BM25Operator    string
+	MinOrTokens     int
+	BM25K1          float64
+	BM25B           float64
+	Tokenization    string
+	FilterCount     int
+
+	// BM25 tombstone generation (slow-path reproduction)
+	TombstonePercentage float64
+	TombstoneMode       string
+	TombstoneIterations int
+	TombstoneConcurrent bool
+	MeasureBaseline     bool
 }
 
 func (c *Config) Validate() error {
@@ -99,6 +117,8 @@ func (c *Config) Validate() error {
 		return c.validateDataset()
 	case "ann-benchmark":
 		return c.validateANN()
+	case "bm25-benchmark":
+		return c.validateBM25()
 	default:
 		return errors.Errorf("unrecognized mode %q", c.Mode)
 	}
@@ -186,6 +206,48 @@ func (c Config) validateANN() error {
 
 	if c.DistanceMetric == "" {
 		return errors.Errorf("distance metric must be set")
+	}
+
+	return nil
+}
+
+func (c Config) validateBM25() error {
+	if c.API != "grpc" {
+		return errors.Errorf("only grpc is supported for bm25-benchmark")
+	}
+
+	if !c.QueryOnly && c.CorpusFile == "" {
+		return errors.Errorf("a corpus file (--corpus, BEIR corpus.jsonl) must be provided unless --query is set")
+	}
+
+	if c.QueriesFile == "" {
+		return errors.Errorf("a queries file (--queriesFile, BEIR queries.jsonl) must be provided")
+	}
+
+	switch c.TombstoneMode {
+	case "", "update", "delete":
+	default:
+		return errors.Errorf("unsupported tombstoneMode %q, must be one of [update, delete]", c.TombstoneMode)
+	}
+
+	if c.TombstonePercentage < 0 || c.TombstonePercentage > 1 {
+		return errors.Errorf("tombstonePercentage must be between 0 and 1")
+	}
+
+	if c.TombstonePercentage > 0 && c.CorpusFile == "" {
+		return errors.Errorf("a corpus file (--corpus) is required to generate tombstones")
+	}
+
+	if c.TombstoneConcurrent && c.QueryDuration <= 0 {
+		return errors.Errorf("--tombstoneConcurrent requires --queryDuration > 0 so queries overlap the background churn")
+	}
+
+	if c.TombstoneConcurrent && c.TombstoneMode == "delete" {
+		return errors.Errorf("--tombstoneConcurrent requires --tombstoneMode update (delete does not sustain churn)")
+	}
+
+	if c.Parallel < 1 {
+		return errors.Errorf("parallel must be at least 1")
 	}
 
 	return nil

--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -230,6 +230,16 @@ func (c Config) validateBM25() error {
 		return errors.Errorf("a queries file (--queriesFile, BEIR queries.jsonl) must be provided")
 	}
 
+	if c.SearchType != "bm25" {
+		return errors.Errorf("unsupported searchType %q: only \"bm25\" is implemented (hybrid is reserved for a future version)", c.SearchType)
+	}
+
+	switch c.BM25Operator {
+	case "", "or", "and":
+	default:
+		return errors.Errorf("unsupported bm25Operator %q, must be one of [or, and] (empty = server default)", c.BM25Operator)
+	}
+
 	switch c.TombstoneMode {
 	case "", "update", "delete":
 	default:

--- a/benchmarker/cmd/root.go
+++ b/benchmarker/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 	initDataset()
 	initRaw()
 	initAnnBenchmark()
+	initBM25Benchmark()
 	initColbert()
 }
 


### PR DESCRIPTION
## Motivation

We can benchmark ANN query performance today, but we have no equivalent harness for **BM25 keyword search** — and in particular no way to reproduce and quantify the latency degradation that inverted-index **tombstones** cause. When documents are updated or deleted, their old docIDs remain in the posting lists as tombstones and must be skipped at query time until compaction reclaims them. Under update-heavy workloads this can meaningfully hurt BM25 latency/QPS, and we needed a repeatable way to measure it against real corpora.

This PR adds a `bm25-benchmark` command that imports a [BEIR](https://github.com/beir-cellar/beir)-format text corpus into a vectorless collection and measures BM25 latency/QPS through the existing worker-pool harness, with an optional tombstone-generation mode to measure performance under inverted-index churn, and an optional **qrels-based quality regression gate** (`--measureQuality`).

## Approach

The guiding decision was to **reuse the existing import and measurement machinery rather than fork it**:

- `BeirDataset` implements the existing `Dataset` interface, so the same 8-worker `loadTrainData` pipeline imports the corpus unchanged. Vector-specific interface methods are no-ops.
- BM25 queries reuse the shared `benchmark(...)` worker pool and the ANN-compatible JSON result shape, so runs plug straight into existing reporting.
- Tombstone density is measured **phased**: a 0-tombstone baseline, then delete/reinsert a fraction of docs and re-measure per iteration (or sustain churn in the background for a concurrent-churn variant).
- Multi-tenancy is supported: each tenant gets a full corpus copy, and tombstone churn is tenant-aware (per-tenant `Config` copies, no shared mutation).

**Quality gate** (second commit): by default the run is a pure performance test (BM25 top-k is exact, so there is no ANN-style self-recall). With `--measureQuality`, the BEIR **qrels** become the external ground truth: the command computes **NDCG@10 / Recall@100 vs qrels** per phase (pytrec_eval conventions), so a change that degrades *what* BM25 returns — a tombstone or WAND regression — shows up as a metric drop. Rows are labeled `benchmarkType: bm25-qrels` so they are never conflated with ANN metrics downstream. Because a lagging multi-node cluster would otherwise be misread as a quality collapse, quality mode waits for the index to **settle** (judged docs findable via a competition-free probe, then the metric stops climbing) before measuring, and a **retrievability probe** (`tombstoneRetrievability`) checks that reinserted docs remain findable after churn.

The one invasive change is in `ann_benchmark.go`: `Batch`/`writeChunk` were generalized to carry optional text properties so the BM25 path could share them. This was done as a **behavior-preserving refactor** of the existing ANN write path (the loop now iterates over `max(len(vectors), len(text))` and only touches vectors when present).

Hybrid (BM25 + vector) was intentionally left out but the seam is documented in `bm25_query.go`.

## Key areas for review

- `benchmarker/cmd/ann_benchmark.go` `writeChunk` — **the riskiest change**, the only edit to the shared ANN import path. Verify the pure-ANN branches (named vector, multivector, filter-only) are unchanged; note the inner multivector loop variable was renamed `i`→`j` to avoid shadowing the outer object index.
- `benchmarker/cmd/benchmark_run.go` — the shared query path gained a graded-metrics branch (`QueryWithNeighbors.Relevance`), a quality-pass soft-fail, and a mode-gated short-result warning; the ANN branches are untouched (A/B-verified against main: identical recall/NDCG on mnist-784).
- `benchmarker/cmd/bm25_quality.go` `settleMetric` — the settle logic (per-metric maxima, patience, epsilon); unit-tested with scripted poll sequences.
- `benchmarker/cmd/bm25_benchmark.go` `generateTombstones` / `tombstoneOnce` — concurrency safety: these run alongside the query phase in `--tombstoneConcurrent` mode. `cfg` is taken by value so tenant assignment stays local; churn RPCs take a cancellable context and the goroutine join is bounded.
- `benchmarker/cmd/bm25_benchmark.go` `batchDeleteDocIDRange` — the delete loop (server caps deletes at ~10k/call); terminates on `Successful == 0` and propagates errors.
- `benchmarker/cmd/beir_dataset.go` `StreamTrainData` — `startOffset`/`maxRecords` + absolute `Offset` are what make reinsert produce **stable UUIDs/docIds**, which makes "update" a true update rather than a duplicate insert.

## Risks and mitigations

- **Regression in the existing `ann-benchmark` import path**: the `writeChunk` rewrite is behavior-preserving; validated by inspection, the existing suite, and a live A/B run against main (identical recall/NDCG).
- **Race between background churn and queries** (`--tombstoneConcurrent`): mitigated by passing per-tenant `Config` copies (by value) into the churn goroutine; the goroutine is stopped via `stop`/`done` channels with a cancellable context for in-flight RPCs and a bounded join, so a hung server cannot deadlock the run or discard results.
- **UUID/docId drift across reinsert passes** would turn "update" into duplicate inserts: prevented by deriving UUIDs deterministically from the absolute corpus offset, so reinserting reuses identical UUIDs and genuinely overwrites.
- **False quality regressions from index lag**: quality mode gates on findability + metric stability before accepting a measurement; an all-failed quality pass omits recall/ndcg (and the `bm25-qrels` label) instead of reporting 0.0, and rows carry `qualityFailedQueries` so incomplete passes are visible downstream.
- **Oversized corpus lines** (full passages exceed bufio's 64KB default): scanner buffer raised to 16MB.

## Testing

Unit tests (no Weaviate required), passing (`go test ./cmd/...`, incl. `-race`):
- `bm25_query_test.go` — the gRPC query builder: operators, filters, tenants, defaults, and the `Metadata.Uuid == true` invariant.
- `beir_dataset_test.go` / `beir_qrels_test.go` — corpus/query streaming, batch offsets, the range re-stream used by reinsert, qrels parsing (header detection, strict columns, dup guards).
- `benchmark_quality_test.go` — `calculateGradedNDCG` / `recallVsRelevant` vs hand-computed pytrec_eval-convention values.
- `bm25_quality_test.go` — `settleMetric` with scripted poll sequences (per-metric maxima).
- `benchmark_run_test.go` — `analyze` on an all-failed pass (empty times).

Manually validated end-to-end against live Weaviate clusters (single-node and 3-node k8s) on NFCorpus, SciFact and FiQA: import → baseline → tombstone iterations → results JSON; quality values match published BEIR BM25 references (fiqa NDCG@10 = 0.236); query-only mode without `--corpus`; retrievability 1.0 after judged churn.

A self-review pass (2 HIGH / 6 MEDIUM findings: query-only crash, divide-by-zero on all-failed quality pass, missing Bearer auth on raw-gRPC helpers, misleading `tombstoneRatio` under judged churn, concurrent-churn shutdown deadlock, fatal churn errors, silent quality denominators, README drift) was addressed in the fourth commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
